### PR TITLE
Fix waiver roster snapshot selection

### DIFF
--- a/apps/mcp-server/fpl-server/waiver_recommendations.go
+++ b/apps/mcp-server/fpl-server/waiver_recommendations.go
@@ -147,6 +147,17 @@ type liveStats struct {
 	XG          float64
 }
 
+func resolveRosterGW(asOfGW int, targetGW int) int {
+	rosterGW := asOfGW
+	if targetGW > 1 && targetGW-1 > rosterGW {
+		rosterGW = targetGW - 1
+	}
+	if rosterGW < 1 {
+		rosterGW = 1
+	}
+	return rosterGW
+}
+
 func buildWaiverRecommendations(cfg ServerConfig, args WaiverRecommendationsArgs) ([]byte, error) {
 	if args.LeagueID == 0 {
 		return nil, fmt.Errorf("league_id is required")
@@ -268,6 +279,7 @@ func buildWaiverRecommendations(cfg ServerConfig, args WaiverRecommendationsArgs
 		return nil, err
 	}
 	targetGW := nextGW
+	rosterGW := resolveRosterGW(asOfGW, targetGW)
 
 	bootstrap, teamShort, fixturesByGW, err := loadBootstrapData(cfg.RawRoot)
 	if err != nil {
@@ -275,7 +287,10 @@ func buildWaiverRecommendations(cfg ServerConfig, args WaiverRecommendationsArgs
 	}
 	fixtureByTeam := buildFixtureIndex(fixturesByGW[targetGW], teamShort)
 
-	leagueSummary, err := loadLeagueSummary(cfg, args.LeagueID, asOfGW)
+	leagueSummary, err := loadLeagueSummary(cfg, args.LeagueID, rosterGW)
+	if err != nil && rosterGW != asOfGW {
+		leagueSummary, err = loadLeagueSummary(cfg, args.LeagueID, asOfGW)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/apps/mcp-server/fpl-server/waiver_recommendations_test.go
+++ b/apps/mcp-server/fpl-server/waiver_recommendations_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+func TestResolveRosterGW(t *testing.T) {
+	tests := []struct {
+		name   string
+		asOf   int
+		target int
+		want   int
+	}{
+		{
+			name:   "UseTargetMinusOneWhenAhead",
+			asOf:   25,
+			target: 27,
+			want:   26,
+		},
+		{
+			name:   "KeepAsOfWhenAlreadyCurrent",
+			asOf:   26,
+			target: 27,
+			want:   26,
+		},
+		{
+			name:   "KeepAsOfForEarlyTarget",
+			asOf:   1,
+			target: 1,
+			want:   1,
+		},
+		{
+			name:   "ClampToOne",
+			asOf:   0,
+			target: 1,
+			want:   1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveRosterGW(tc.asOf, tc.target)
+			if got != tc.want {
+				t.Fatalf("resolveRosterGW(%d, %d)=%d want %d", tc.asOf, tc.target, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Use the target GW-1 roster snapshot when the current GW is in progress so recently dropped players are not suggested again.
- Add unit coverage for roster GW selection.

## Testing
- scripts/preflight.sh