### PR TITLE
chore(workflows): restrict all review workflows to dev→stage and stage→main

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,20 +3,16 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # Restrict to the two gated branch transitions only.
+    # Feature-branch PRs are excluded to keep token usage low.
+    branches: [stage, main]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only run on the two branch transitions we care about (dev→stage, stage→main).
+    if: |
+      (github.base_ref == 'stage' && github.head_ref == 'dev') ||
+      (github.base_ref == 'main'  && github.head_ref == 'stage')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -3,6 +3,8 @@ name: Codex Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    # Restrict to the two gated branch transitions; feature-branch PRs are excluded.
+    branches: [stage, main]
   workflow_dispatch:
 
 permissions:
@@ -12,6 +14,11 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Only run on the two branch transitions we care about (dev→stage, stage→main).
+    if: |
+      (github.base_ref == 'stage' && github.head_ref == 'dev') ||
+      (github.base_ref == 'main'  && github.head_ref == 'stage') ||
+      github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

- `codex-review.yml` was triggering on every PR (including feature branches). Added `branches: [stage, main]` and a job-level `if` to restrict to `dev→stage` and `stage→main` only.
- `claude-code-review.yml` (added by GitHub App) had the same problem. Same fix applied.

This keeps AI review costs low — only gated transitions get reviewed, not every feature branch push.

## Tests
- No logic changes; workflow trigger restrictions only.
- `go test ./...` ✅  `ruff check` ✅  `pytest` ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)