### PR TITLE
refactor(agent): consolidate _extract_* methods into _extract_param (#27)

### DIFF
--- a/apps/backend/backend/agent.py
+++ b/apps/backend/backend/agent.py
@@ -662,28 +662,16 @@ class Agent:
         return " ".join(labeled)
 
     def _extract_league_id(self, text: str) -> Optional[int]:
-        match = re.search(r"league\s*(?:id)?\s*[:=#]?\s*(\d{4,6})", text, re.IGNORECASE)
-        if match:
-            return int(match.group(1))
-        return None
+        return self._extract_param("league_id", text)
 
     def _extract_gw(self, text: str) -> Optional[int]:
-        match = GW_PATTERN.search(text)
-        if match:
-            return int(match.group(1))
-        return None
+        return self._extract_param("gw", text)
 
     def _extract_horizon(self, text: str) -> Optional[int]:
-        match = re.search(r"horizon\s*[:=#]?\s*(\d{1,2})", text, re.IGNORECASE)
-        if match:
-            return int(match.group(1))
-        return None
+        return self._extract_param("horizon", text)
 
     def _extract_entry_id(self, text: str) -> Optional[int]:
-        match = re.search(r"(?:entry[_\s-]*id|entry)\s*[:=#]?\s*(\d{4,8})", text, re.IGNORECASE)
-        if match:
-            return int(match.group(1))
-        return None
+        return self._extract_param("entry_id", text)
 
     def _normalize_text(self, text: str) -> str:
         return re.sub(r"[^a-z0-9 ]+", " ", text.lower())
@@ -763,6 +751,22 @@ class Agent:
 
     # ---- Intent detectors (existing) ----
 
+
+    # Maps parameter name → compiled regex for extracting a numeric value from text.
+    _PARAM_PATTERNS: Dict[str, Any] = {
+        "league_id": re.compile(r"league\s*(?:id)?\s*[:=#]?\s*(\d{4,6})", re.IGNORECASE),
+        "gw": GW_PATTERN,
+        "horizon": re.compile(r"horizon\s*[:=#]?\s*(\d{1,2})", re.IGNORECASE),
+        "entry_id": re.compile(r"(?:entry[_\s-]*id|entry)\s*[:=#]?\s*(\d{4,8})", re.IGNORECASE),
+    }
+
+    def _extract_param(self, param: str, text: str) -> Optional[int]:
+        """Extract a named numeric parameter from *text* using *_PARAM_PATTERNS*."""
+        pattern = self._PARAM_PATTERNS.get(param)
+        if pattern is None:
+            return None
+        match = pattern.search(text)
+        return int(match.group(1)) if match else None
 
 
     def _looks_like_team_name_only(self, text: str, league_id: int, tool_events: List[Dict[str, Any]]) -> bool:

--- a/apps/backend/backend/agent.py
+++ b/apps/backend/backend/agent.py
@@ -764,6 +764,7 @@ class Agent:
     # ---- Intent detectors (existing) ----
 
 
+
     def _looks_like_team_name_only(self, text: str, league_id: int, tool_events: List[Dict[str, Any]]) -> bool:
         if len(text.split()) > 6:
             return False


### PR DESCRIPTION
## Summary

- Adds `Agent._PARAM_PATTERNS: Dict[str, re.Pattern]` — class-level dict of compiled regexes for each numeric parameter (`league_id`, `gw`, `horizon`, `entry_id`)
- Adds `Agent._extract_param(param, text) -> Optional[int]` — single dispatcher that looks up the pattern and returns the first captured group as an int (or None)
- Converts the four existing `_extract_league_id`, `_extract_gw`, `_extract_horizon`, `_extract_entry_id` methods to one-line wrappers around `_extract_param`, preserving all existing call sites unchanged

## Benefits

- Single source of truth for all extraction patterns — edit the dict to tune a pattern, no need to hunt through method bodies
- Patterns are compiled once at class definition time instead of on every call
- `_extract_param` enables future callers to extract any named parameter generically

## Test plan
- [ ] `ruff check apps/backend` — no errors
- [ ] `pytest apps/backend/tests` — 2 passed
- [ ] Verify `_extract_param("gw", "gameweek 5")` returns `5`
- [ ] Verify `_extract_param("league_id", "league 14204")` returns `14204`

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)