### PR TITLE
chore: session summary — Thursday 19 February 2026

### DIFF
--- a/docs/sessions/2026-02-19.md
+++ b/docs/sessions/2026-02-19.md
@@ -1,0 +1,29 @@
+# Session Notes — Thursday 19 February 2026
+
+This file tracks PRs opened in the Claude Code sessions on 18–19 February 2026.
+
+## Session 1 (18 Feb)
+
+- **#23** `fix(waivers)`: Implement `resolveRosterGW` — fix dropped players re-appearing as drop candidates
+- **#24** `chore(workflows)`: Restrict review workflows to `dev→stage` and `stage→main` transitions only
+
+## Session 2 (19 Feb)
+
+- **#37** `feat`: Add 6 new MCP tools (`current_roster`, `draft_picks`, `manager_season`, `transaction_analysis`, `player_gw_stats`, `head_to_head`), refactor agent routing (LLM-first, `_INTENT_KEYWORDS`, `max_steps` 4→6), fix issues #25 and #31
+- **#38** `fix(ci)`: Retire Codex workflows and duplicate Claude review (#32)
+- **#39** `docs(config)`: Document all Settings fields in `.env.example` (#34)
+- **#40** `refactor(constants)`: Extract `POSITION_TYPE_LABELS` to shared constants module (#28)
+- **#41** `refactor(constants)`: Extract `GW_PATTERN` regex; fix double-escaped `\\s*` bug in `rag.py` (#33)
+- **#42** `refactor(agent)`: Replace session `dict` with typed `AgentSession` TypedDict (#36)
+- **#43** `refactor(agent)`: Consolidate 17 `_looks_like_*` methods into `_INTENT_KEYWORDS` table (#26)
+- **#44** `refactor(agent)`: Consolidate 4 `_extract_*` methods into `_extract_param` dispatcher (#27)
+- **#45** `docs(backend)`: Add docstrings to `Agent`, `reports.py`, `server.py`, `RAGIndex` (#35)
+- **#46** `test(agent)`: Add 49 Python tests (intent routing, param extraction, `_apply_defaults`, handlers) (#29)
+- **#47** `test(go)`: Add 17 Go tests (`resultFromScore`, `positionLabel`, `horizonWeights`, `buildHeadToHead`, `buildManagerSeason`, `buildManagerStreak`) (#30)
+
+## Test coverage after session 2
+
+| Suite | Count |
+|---|---|
+| Go `go test ./fpl-server/...` | 21 (17 new) |
+| Python `pytest apps/backend/tests` | 51 (49 new) |


### PR DESCRIPTION
# Session Summary — Thursday 19 February 2026, 06:00

This PR tracks all work completed across **two Claude Code sessions** on this repo and adds a `docs/sessions/2026-02-19.md` session notes file.

---

## Previous Session (Session 1)

### Infrastructure & CI (#22, #24)
- Set up Claude Code GitHub App and automated CI workflows
- Added `claude-review.yml`, `claude-issue.yml`, `claude.yml`
- Restricted all review workflows to `dev→stage` and `stage→main` transitions only

### Bug Fix: Waiver Roster Ownership (#23)
- Fixed `resolveRosterGW` — dropped players re-appeared as drop candidates because the wrong snapshot GW was selected
- Added `RosterGW` field to `WaiverRecommendationsReport` and wired it into `buildWaiverRecommendations`

---

## This Session (Session 2)

### Feature: 6 New MCP Tools + Agent Refactor (#37)

New Go tools in `apps/mcp-server/fpl-server/`:

| Tool | What it answers |
|---|---|
| `current_roster` | A manager's squad for a given GW |
| `draft_picks` | Full draft order and history |
| `manager_season` | GW-by-GW results and season record |
| `transaction_analysis` | League-wide add/drop patterns by position |
| `player_gw_stats` | A player's per-GW point totals |
| `head_to_head` | H2H record between two managers |

Agent refactored to be LLM-first; `max_steps` raised 4→6; hardcoded IDs fixed (#25, #31).

---

### Issues #32–#36, #26–#30 (PRs #38–#47)

| PR | Issue | Summary |
|---|---|---|
| #38 | #32 | Remove `codex-review.yml`, `claude-code-review.yml`, `issue-codex.yml` |
| #39 | #34 | Full `.env.example` with comments for every `Settings` field |
| #40 | #28 | `POSITION_TYPE_LABELS` constant in `constants.py` |
| #41 | #33 | `GW_PATTERN` compiled regex; fix `rag.py` double-escape bug |
| #42 | #36 | `AgentSession(TypedDict)` replaces `Dict[str, Any]` session state |
| #43 | #26 | `_INTENT_KEYWORDS` table + `_looks_like()` dispatcher replaces 17 methods |
| #44 | #27 | `_PARAM_PATTERNS` dict + `_extract_param()` replaces 4 extractor methods |
| #45 | #35 | Google-style docstrings across `agent.py`, `reports.py`, `server.py`, `rag.py` |
| #46 | #29 | 49 Python tests (routing, extraction, defaults, handlers) |
| #47 | #30 | 17 Go tests (score logic, position labels, horizon weights, H2H, season, streak) |

---

## Test coverage

| Suite | Tests |
|---|---|
| Go | 21 (17 new) |
| Python | 51 (49 new) |

---

## Recommended merge order for PRs into `dev`

`#38 → #39 → #37 → #40 → #41 → #42 → #43 → #44 → #45 → #46 → #47`

🤖 Generated with [Claude Code](https://claude.com/claude-code)