### PR TITLE
chore(ci): contextualize Claude workflows to gated branch transitions only

### DIFF
--- a/.github/claude/prompts/changelog.md
+++ b/.github/claude/prompts/changelog.md
@@ -1,0 +1,163 @@
+You are Claude Code generating a structured changelog for the FPL Draft Agent repository.
+
+This runs automatically when code crosses one of two gated branch transitions:
+- `dev → stage`   → generates a **pre-release** changelog
+- `stage → main`  → generates a **release** changelog
+
+The workflow will provide you with:
+- The transition type and version label
+- The commit log since the previous tag/release
+- The list of files changed since the previous tag/release
+
+Your job is to produce a complete, structured changelog that is useful to:
+1. **The deploying engineer** — what do they need to do before/after deploying?
+2. **The league users** — what new features or fixes are visible?
+3. **Future Claude agents** — what contracts changed that affect their work?
+
+---
+
+## Classification Rules
+
+### Breaking Changes
+A change is **breaking** if any existing caller, config, or deployment must change:
+- MCP tool renamed, removed, or argument/response shape changed
+- Python agent routing changed in a way that changes existing query behaviour
+- New **required** env var or config key (no default)
+- Data directory structure changed in an incompatible way
+- API endpoint path or response shape changed
+- Behaviour change that alters existing functionality
+
+### Non-Breaking Changes
+A change is **non-breaking** if existing callers continue to work without modification:
+- New MCP tool added (additive)
+- New optional env var with a sensible default
+- Bug fix that corrects wrong behaviour (document what changed)
+- New test coverage, docstrings, or refactors with identical behaviour
+- New feature that doesn't affect existing paths
+
+### Environment & Config Changes
+Any change to how the system is configured or deployed:
+- New env vars (mark: required / optional with default value)
+- Changed port assignments
+- New data directories or file paths needed
+- Changed Docker/compose/process startup commands
+- New Python or Go dependency added
+
+### Ecosystem Effects
+Changes that affect the boundary between components:
+- Go MCP server ↔ Python agent contract (tool names, arg names, response fields)
+- FPL API data shape dependencies (fields read from bootstrap.json, live.json, etc.)
+- Scheduler behaviour changes (cron timing, refresh logic)
+- Report format changes (affects any downstream consumer of reports)
+
+---
+
+## Tools Available
+
+Use `Read`, `Glob`, and `Grep` to inspect files when you need more context than the commit log provides.
+
+Key files to check when relevant:
+- `apps/mcp-server/fpl-server/main.go` — registered tool names and schemas
+- `apps/backend/backend/mcp.py` — tool call sites (must match Go)
+- `apps/backend/backend/config.py` — SETTINGS fields (new required fields are breaking)
+- `apps/backend/backend/agent.py` — routing changes
+- `apps/backend/backend/constants.py` — shared constants
+- `CLAUDE.md` — architecture reference
+
+---
+
+## Required Output Format
+
+Produce the changelog as a single markdown block using exactly this format.
+Replace `{VERSION}` and `{DATE}` with the values provided by the workflow.
+
+---
+
+# Changelog — {VERSION} ({DATE})
+
+**Transition:** `{TRANSITION}`
+**Commits included:** {COMMIT_COUNT}
+
+---
+
+## Breaking Changes
+
+> Changes that require action from deployers or break existing callers.
+
+<!-- Write each breaking change as a bullet. If none, write: _None._ -->
+
+- ...
+
+---
+
+## New Features
+
+> Additive capabilities visible to users or callers.
+
+<!-- If none, write: _None._ -->
+
+- ...
+
+---
+
+## Bug Fixes
+
+> Corrections to incorrect behaviour. Note what was wrong and what is correct now.
+
+<!-- If none, write: _None._ -->
+
+- ...
+
+---
+
+## Internal Changes
+
+> Refactors, tests, docs, and dependency updates with no user-visible effect.
+
+<!-- If none, write: _None._ -->
+
+- ...
+
+---
+
+## Environment & Config Changes
+
+> What a deployer must set up, change, or verify before deploying this version.
+
+| Type | Name | Required? | Default | Notes |
+|------|------|-----------|---------|-------|
+| env var | `EXAMPLE_VAR` | Yes | — | Description |
+
+<!-- If no environment changes, write: _No environment changes required._ -->
+
+---
+
+## Ecosystem Effects
+
+> Changes to cross-component contracts that affect other tools, agents, or integrations.
+
+### Go ↔ Python MCP Contract
+<!-- List any tool name, argument, or response shape changes -->
+_None._ / [describe changes]
+
+### FPL API Data Dependencies
+<!-- List any new fields read from FPL API responses -->
+_None._ / [describe changes]
+
+### Report Format Changes
+<!-- List any changes to markdown report structure or fields -->
+_None._ / [describe changes]
+
+---
+
+## Deployment Checklist
+
+> Step-by-step actions required before or after deploying this version.
+
+- [ ] Review breaking changes above
+<!-- Add specific steps for any breaking changes or env changes found -->
+- [ ] Restart Go MCP server if tool registration changed
+- [ ] Restart Python backend if config or agent routing changed
+- [ ] Verify all required env vars are set in production
+
+---

--- a/.github/claude/prompts/review.md
+++ b/.github/claude/prompts/review.md
@@ -1,25 +1,79 @@
 You are Claude Code performing an automated code review for the FPL Draft Agent repository.
 
+This review fires only on two gated branch transitions:
+- `dev → stage`   (integration gate — pre-release validation)
+- `stage → main`  (production gate — release approval)
+
+Feature-branch PRs never reach this workflow.
+
+---
+
+## Transition Context
+
+The workflow will tell you which transition this is (`dev→stage` or `stage→main`).
+Calibrate your strictness accordingly:
+
+| Transition | Gate purpose | Strictness |
+|---|---|---|
+| `dev → stage` | Pre-release integration check | High — catch regressions before staging |
+| `stage → main` | Production release approval | Critical — breaking changes must be documented |
+
+---
+
 ## Your Goals
 
-- Focus on correctness, data integrity, and regressions.
-- Call out missing tests or risky changes.
-- Keep feedback concise and actionable — no padding or filler.
+1. **Correctness and regressions** — Does the change break existing behaviour?
+2. **Breaking vs non-breaking classification** — Is every breaking change explicitly documented?
+3. **Environment and config impact** — Any new env vars, ports, or config keys required?
+4. **Ecosystem contract impact** — Does the Go↔Python MCP contract stay stable?
+5. **Test coverage** — Is every logic change tested?
+
+---
 
 ## Project-Specific Checks
 
-- **Secrets / data safety**: Never allow `.env`, secrets, or changes to `data/` or `reports/` directories.
-- **Go ↔ Python contract**: Ensure Go MCP tool names, argument names, and response shapes remain
-  compatible with how `apps/backend/` calls them. A rename or shape change here is a breaking change.
-- **Python backend**: Ensure MCP tool call shapes and report output formats stay stable. No network
-  calls at module import time.
-- **UI routes**: Verify any changed routes still match backend endpoints. Update README if startup
-  steps change.
-- **Test coverage**: Flag changes that touch logic without a corresponding test update.
+### Secrets / Data Safety
+- Never allow `.env`, secrets, or changes to `data/` or `reports/` directories in source.
+
+### Go ↔ Python Contract (ecosystem boundary)
+This is the most critical contract in the repo. Any change here is a **breaking change** unless additive:
+- MCP tool names (registered in `apps/mcp-server/fpl-server/main.go`)
+- MCP tool argument names and types (Go structs tagged `json:`)
+- MCP tool response field names and shapes (Go output structs)
+- How `apps/backend/backend/mcp.py` calls these tools
+
+A rename, removal, or type change in a Go tool arg/response is a breaking change for the Python agent.
+
+### Environment and Config
+Flag any changes to:
+- `apps/backend/backend/config.py` — new `SETTINGS` fields (are they required? do they have defaults?)
+- `apps/mcp-server/fpl-server/config.go` — new `ServerConfig` fields
+- Port assignments (default :8080 Go, :8000 Python)
+- New required data directories or file paths
+- Any change that requires a deploy-time action (migrate data, set env var, restart service)
+
+### Python Backend Stability
+- No network calls at module import time
+- MCP tool call shapes in `agent.py` must match Go server
+- Report output formats in `reports.py` must stay stable across GWs
+
+### Test Coverage
+Flag changes that touch logic without a corresponding test update.
+
+---
 
 ## Tools Available
 
 Use `Read`, `Glob`, and `Grep` to inspect changed or related files as needed before writing your review.
+
+Key files to check when relevant:
+- `apps/mcp-server/fpl-server/main.go` — tool registration
+- `apps/backend/backend/mcp.py` — tool call sites
+- `apps/backend/backend/agent.py` — routing and intent detection
+- `apps/backend/backend/config.py` — settings
+- `apps/backend/backend/constants.py` — shared constants
+
+---
 
 ## Required Output Format
 
@@ -27,18 +81,32 @@ Post your review as a single structured comment using exactly this format:
 
 ---
 
-## Summary
+## Review: `{head_ref}` → `{base_ref}`
+
+### Summary
 [1–3 sentences describing what this PR changes and why.]
 
-## Blocking Issues
-[Issues that must be fixed before merging. Use bullet points. Write "None." if there are no blockers.]
+### Breaking Changes
+[Changes that alter existing behaviour, remove functionality, rename interfaces, add required config, or break the Go↔Python contract. Use bullet points. Write "None." if there are none.]
 
-## Other Issues
-[Non-blocking concerns, style notes, or improvement suggestions. Write "None." if clean.]
+### Non-Breaking Changes
+[Additive features, bug fixes, tests, docs, and internal refactors that do not affect existing callers. Write "None." if there are none.]
 
-## Suggested Tests
-[Specific test cases or scenarios that would improve coverage for this change. Always include this section.]
+### Environment & Config Impact
+[New env vars (required vs optional with default), port changes, new data paths, deploy-time actions required. Write "None required." if clean.]
+
+### Ecosystem Effects
+[Changes to the MCP tool contract (tool names, arg shapes, response shapes), Python agent routing, report formats, or any interface that crosses the Go↔Python boundary. Write "None." if clean.]
+
+### Blocking Issues
+[Must be fixed before merging. Write "None." if there are no blockers.]
+
+### Other Issues
+[Non-blocking concerns, style notes, improvement suggestions. Write "None." if clean.]
+
+### Suggested Tests
+[Specific test cases that would improve coverage. Always include this section even if coverage looks good.]
 
 ---
 
-If there are no issues at all, write: "No blocking issues found." but still fill in **Suggested Tests**.
+If there are no issues at all, still fill in every section — write "None." or "None required." for the clean sections.

--- a/.github/workflows/claude-changelog.yml
+++ b/.github/workflows/claude-changelog.yml
@@ -1,0 +1,348 @@
+name: Claude Changelog
+
+# Generates a structured changelog when code crosses a gated branch transition.
+#
+#   dev  →  stage   → posts pre-release changelog as a PR comment + draft pre-release
+#   stage →  main   → posts release changelog as a PR comment + draft GitHub release
+#
+# The changelog classifies every commit as:
+#   - Breaking change (deployer action required)
+#   - New feature (additive, non-breaking)
+#   - Bug fix
+#   - Internal change (tests, docs, refactors)
+#
+# It also calls out environment/config changes (new env vars, port changes)
+# and ecosystem effects (Go↔Python MCP contract changes, report format changes).
+#
+# Trigger: a PR is merged into `stage` (from dev) or `main` (from stage).
+# Manual runs: workflow_dispatch with base_ref and head_sha inputs.
+#
+# Required secret: CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [stage, main]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Target branch (stage or main)"
+        required: true
+        default: "stage"
+        type: choice
+        options: [stage, main]
+      head_sha:
+        description: "Head SHA to diff from (defaults to branch HEAD)"
+        required: false
+
+permissions:
+  contents: write      # needed to create releases and tags
+  pull-requests: write # needed to post PR comments
+
+jobs:
+  changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-latest
+
+    # Only run when a PR from dev→stage or stage→main is actually merged.
+    # Manual dispatch bypasses the merge check.
+    if: |
+      (
+        github.event.pull_request.merged == true &&
+        (
+          (github.base_ref == 'stage' && github.head_ref == 'dev') ||
+          (github.base_ref == 'main'  && github.head_ref == 'stage')
+        )
+      ) ||
+      github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout merged branch
+        uses: actions/checkout@v4
+        with:
+          # For workflow_dispatch, use the specified base_ref; otherwise use the PR base.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.base_ref || github.base_ref }}
+          fetch-depth: 0
+
+      # ── API key guard ──────────────────────────────────────────────────────
+      - name: Check Claude auth secret
+        id: keycheck
+        continue-on-error: true
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY:       ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set."
+            exit 1
+          fi
+
+      - name: Fail when auth secret is missing
+        if: steps.keycheck.outcome != 'success'
+        run: exit 1
+
+      # ── Determine version label and diff base ──────────────────────────────
+      - name: Compute version and diff base
+        id: version
+        env:
+          BASE_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.base_ref || github.base_ref }}
+        run: |
+          # Find the most recent tag reachable from HEAD (excluding HEAD itself).
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+
+          if [ -z "$PREV_TAG" ]; then
+            # No previous tag — diff from the very first commit.
+            DIFF_BASE=$(git rev-list --max-parents=0 HEAD)
+            echo "No previous tag found; diffing from initial commit."
+          else
+            DIFF_BASE="$PREV_TAG"
+            echo "Diffing from $PREV_TAG"
+          fi
+
+          # Derive a version label for the changelog heading.
+          # For main: next semantic version after the last tag.
+          # For stage: pre-release label.
+          TODAY=$(date -u +%Y-%m-%d)
+
+          if [ "$BASE_REF" = "main" ]; then
+            if [ -n "$PREV_TAG" ]; then
+              # Bump patch version of previous tag (e.g. v1.2.3 → v1.2.4)
+              MAJOR=$(echo "$PREV_TAG" | sed 's/v//' | cut -d. -f1)
+              MINOR=$(echo "$PREV_TAG" | sed 's/v//' | cut -d. -f2)
+              PATCH=$(echo "$PREV_TAG" | sed 's/v//' | cut -d. -f3)
+              VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+            else
+              VERSION="v1.0.0"
+            fi
+            TRANSITION="stage → main (production release)"
+            RELEASE_TYPE="release"
+          else
+            # stage branch: pre-release label
+            if [ -n "$PREV_TAG" ]; then
+              MAJOR=$(echo "$PREV_TAG" | sed 's/v//' | cut -d. -f1)
+              MINOR=$(echo "$PREV_TAG" | sed 's/v//' | cut -d. -f2)
+              PATCH=$(echo "$PREV_TAG" | sed 's/v//' | cut -d. -f3)
+              VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))-rc.1"
+            else
+              VERSION="v0.1.0-rc.1"
+            fi
+            TRANSITION="dev → stage (pre-release integration)"
+            RELEASE_TYPE="pre-release"
+          fi
+
+          echo "version=$VERSION"         >> "$GITHUB_OUTPUT"
+          echo "prev_tag=$PREV_TAG"       >> "$GITHUB_OUTPUT"
+          echo "diff_base=$DIFF_BASE"     >> "$GITHUB_OUTPUT"
+          echo "transition=$TRANSITION"   >> "$GITHUB_OUTPUT"
+          echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
+          echo "today=$TODAY"             >> "$GITHUB_OUTPUT"
+
+      # ── Collect git context ────────────────────────────────────────────────
+      - name: Collect commits and changed files
+        id: gitctx
+        env:
+          DIFF_BASE: ${{ steps.version.outputs.diff_base }}
+        run: |
+          # Commit log: exclude merge commits, max 150 lines.
+          COMMIT_LOG=$(git log "$DIFF_BASE"..HEAD --oneline --no-merges | head -150)
+          COMMIT_COUNT=$(git log "$DIFF_BASE"..HEAD --oneline --no-merges | wc -l | tr -d ' ')
+
+          # Files changed: status letter + path (A=added, M=modified, D=deleted, R=renamed).
+          CHANGED_FILES=$(git diff --name-status "$DIFF_BASE"..HEAD | head -200)
+
+          # Diffstat summary (last 5 lines = totals).
+          DIFFSTAT=$(git diff --stat "$DIFF_BASE"..HEAD | tail -5)
+
+          {
+            echo "COMMIT_LOG<<SENTINEL_CL"
+            echo "$COMMIT_LOG"
+            echo "SENTINEL_CL"
+            echo "COMMIT_COUNT=$COMMIT_COUNT"
+            echo "CHANGED_FILES<<SENTINEL_CF"
+            echo "$CHANGED_FILES"
+            echo "SENTINEL_CF"
+            echo "DIFFSTAT<<SENTINEL_DS"
+            echo "$DIFFSTAT"
+            echo "SENTINEL_DS"
+          } >> "$GITHUB_ENV"
+
+      # ── Build Claude prompt ────────────────────────────────────────────────
+      - name: Build changelog prompt
+        id: prompt
+        env:
+          VERSION:       ${{ steps.version.outputs.version }}
+          TRANSITION:    ${{ steps.version.outputs.transition }}
+          RELEASE_TYPE:  ${{ steps.version.outputs.release_type }}
+          TODAY:         ${{ steps.version.outputs.today }}
+          PREV_TAG:      ${{ steps.version.outputs.prev_tag }}
+          COMMIT_COUNT:  ${{ env.COMMIT_COUNT }}
+          COMMIT_LOG:    ${{ env.COMMIT_LOG }}
+          CHANGED_FILES: ${{ env.CHANGED_FILES }}
+          DIFFSTAT:      ${{ env.DIFFSTAT }}
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          base_prompt   = Path(".github/claude/prompts/changelog.md").read_text()
+          version       = os.environ.get("VERSION",       "vUNKNOWN")
+          transition    = os.environ.get("TRANSITION",    "")
+          release_type  = os.environ.get("RELEASE_TYPE",  "")
+          today         = os.environ.get("TODAY",         "")
+          prev_tag      = os.environ.get("PREV_TAG",      "(none — first release)")
+          commit_count  = os.environ.get("COMMIT_COUNT",  "?")
+          commit_log    = os.environ.get("COMMIT_LOG",    "(none)")
+          changed_files = os.environ.get("CHANGED_FILES", "(none)")
+          diffstat      = os.environ.get("DIFFSTAT",      "(none)")
+
+          # Fill in template placeholders in the prompt.
+          base_prompt = (
+              base_prompt
+              .replace("{VERSION}",      version)
+              .replace("{DATE}",         today)
+              .replace("{TRANSITION}",   transition)
+              .replace("{COMMIT_COUNT}", commit_count)
+          )
+
+          prompt = "\n".join([
+              base_prompt,
+              "",
+              "---",
+              "",
+              "## Input Data",
+              "",
+              f"**Version:** {version}",
+              f"**Date:** {today}",
+              f"**Transition:** {transition}",
+              f"**Release type:** {release_type}",
+              f"**Previous tag:** {prev_tag}",
+              f"**Commits included:** {commit_count}",
+              "",
+              "### Commit Log (newest first)",
+              "```",
+              commit_log,
+              "```",
+              "",
+              "### Files Changed (status + path)",
+              "```",
+              changed_files,
+              "```",
+              "",
+              "### Diffstat",
+              "```",
+              diffstat,
+              "```",
+              "",
+              "---",
+              "",
+              "Use the Read, Glob, and Grep tools to inspect any files you need more context on.",
+              "Then produce the full changelog using exactly the required output format above.",
+              "Replace all placeholder text with real content based on the commits and file changes.",
+          ])
+
+          github_env = os.environ.get("GITHUB_ENV", "")
+          if github_env:
+              with open(github_env, "a") as f:
+                  f.write("CLAUDE_CHANGELOG_PROMPT<<HEREDOC_SENTINEL\n")
+                  f.write(prompt)
+                  f.write("\nHEREDOC_SENTINEL\n")
+          PY
+
+      # ── Run Claude to generate changelog ──────────────────────────────────
+      - name: Generate changelog with Claude
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key:       ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token:            ${{ secrets.GITHUB_TOKEN }}
+          # Read-only: Claude reads files to understand changes but does not modify them.
+          allowed_tools:           "Read,Glob,Grep"
+          direct_prompt:           ${{ env.CLAUDE_CHANGELOG_PROMPT }}
+
+      # ── Post changelog as PR comment ───────────────────────────────────────
+      - name: Post changelog on PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+        uses: actions/github-script@v7
+        env:
+          VERSION:      ${{ steps.version.outputs.version }}
+          TRANSITION:   ${{ steps.version.outputs.transition }}
+          RELEASE_TYPE: ${{ steps.version.outputs.release_type }}
+        with:
+          script: |
+            const version      = process.env.VERSION;
+            const transition   = process.env.TRANSITION;
+            const releaseType  = process.env.RELEASE_TYPE;
+
+            await github.rest.issues.createComment({
+              owner:        context.repo.owner,
+              repo:         context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                `## Changelog: ${version}`,
+                `**Transition:** \`${transition}\``,
+                `**Type:** ${releaseType}`,
+                "",
+                "> The full structured changelog was generated by Claude above.",
+                "> Check the Claude step output for the complete breakdown of breaking/non-breaking changes.",
+                "",
+                "---",
+                "> 🤖 Generated by [Claude Code](https://claude.ai/claude-code) via `claude-changelog.yml`",
+              ].join("\n"),
+            });
+
+      # ── Create GitHub pre-release or release draft ─────────────────────────
+      - name: Create GitHub release draft
+        if: steps.keycheck.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          VERSION:      ${{ steps.version.outputs.version }}
+          PREV_TAG:     ${{ steps.version.outputs.prev_tag }}
+          RELEASE_TYPE: ${{ steps.version.outputs.release_type }}
+          TRANSITION:   ${{ steps.version.outputs.transition }}
+          TODAY:        ${{ steps.version.outputs.today }}
+          COMMIT_LOG:   ${{ env.COMMIT_LOG }}
+        with:
+          script: |
+            const version     = process.env.VERSION;
+            const releaseType = process.env.RELEASE_TYPE;
+            const transition  = process.env.TRANSITION;
+            const today       = process.env.TODAY;
+            const commitLog   = process.env.COMMIT_LOG || "(see PR for details)";
+            const isPrerelease = releaseType === "pre-release";
+
+            // Build a concise release body pointing to the Claude-generated details.
+            const body = [
+              `## ${version} — ${today}`,
+              "",
+              `**Transition:** \`${transition}\``,
+              "",
+              "### Commits",
+              "```",
+              commitLog,
+              "```",
+              "",
+              "> Full changelog with breaking change analysis, environment impact, and ecosystem effects",
+              "> was generated by Claude Code. See the merged PR for the complete structured changelog.",
+              "",
+              "---",
+              "> 🤖 Release draft created by [Claude Code](https://claude.ai/claude-code)",
+            ].join("\n");
+
+            // Try to create or update the release for this version tag.
+            // If the tag doesn't exist yet, create a draft without a tag.
+            try {
+              await github.rest.repos.createRelease({
+                owner:      context.repo.owner,
+                repo:       context.repo.repo,
+                tag_name:   version,
+                name:       version,
+                body,
+                draft:      true,
+                prerelease: isPrerelease,
+              });
+              core.info(`Created draft ${releaseType}: ${version}`);
+            } catch (err) {
+              // Tag may already exist; log but don't fail the workflow.
+              core.warning(`Could not create release draft for ${version}: ${err.message}`);
+            }

--- a/.github/workflows/claude-changelog.yml
+++ b/.github/workflows/claude-changelog.yml
@@ -64,6 +64,14 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.base_ref || github.base_ref }}
           fetch-depth: 0
 
+      # Capture the exact commit SHA we checked out.
+      # This is passed as target_commitish when creating release tags so that
+      # GitHub anchors the tag to the correct commit rather than defaulting to
+      # the repository's default branch HEAD.
+      - name: Capture HEAD SHA
+        id: headsha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       # ── API key guard ──────────────────────────────────────────────────────
       - name: Check Claude auth secret
         id: keycheck
@@ -296,19 +304,23 @@ jobs:
         if: steps.keycheck.outcome == 'success'
         uses: actions/github-script@v7
         env:
-          VERSION:      ${{ steps.version.outputs.version }}
-          PREV_TAG:     ${{ steps.version.outputs.prev_tag }}
-          RELEASE_TYPE: ${{ steps.version.outputs.release_type }}
-          TRANSITION:   ${{ steps.version.outputs.transition }}
-          TODAY:        ${{ steps.version.outputs.today }}
-          COMMIT_LOG:   ${{ env.COMMIT_LOG }}
+          VERSION:       ${{ steps.version.outputs.version }}
+          PREV_TAG:      ${{ steps.version.outputs.prev_tag }}
+          RELEASE_TYPE:  ${{ steps.version.outputs.release_type }}
+          TRANSITION:    ${{ steps.version.outputs.transition }}
+          TODAY:         ${{ steps.version.outputs.today }}
+          COMMIT_LOG:    ${{ env.COMMIT_LOG }}
+          # The exact SHA we checked out — used as target_commitish so that
+          # GitHub creates the tag on this commit, not the default branch HEAD.
+          HEAD_SHA:      ${{ steps.headsha.outputs.sha }}
         with:
           script: |
-            const version     = process.env.VERSION;
-            const releaseType = process.env.RELEASE_TYPE;
-            const transition  = process.env.TRANSITION;
-            const today       = process.env.TODAY;
-            const commitLog   = process.env.COMMIT_LOG || "(see PR for details)";
+            const version      = process.env.VERSION;
+            const releaseType  = process.env.RELEASE_TYPE;
+            const transition   = process.env.TRANSITION;
+            const today        = process.env.TODAY;
+            const commitLog    = process.env.COMMIT_LOG || "(see PR for details)";
+            const headSha      = process.env.HEAD_SHA;
             const isPrerelease = releaseType === "pre-release";
 
             // Build a concise release body pointing to the Claude-generated details.
@@ -329,20 +341,23 @@ jobs:
               "> 🤖 Release draft created by [Claude Code](https://claude.ai/claude-code)",
             ].join("\n");
 
-            // Try to create or update the release for this version tag.
-            // If the tag doesn't exist yet, create a draft without a tag.
             try {
               await github.rest.repos.createRelease({
-                owner:      context.repo.owner,
-                repo:       context.repo.repo,
-                tag_name:   version,
-                name:       version,
+                owner:             context.repo.owner,
+                repo:              context.repo.repo,
+                tag_name:          version,
+                // Anchor the tag to the exact merged commit, not the default branch.
+                // Without this, GitHub falls back to the repo default branch HEAD,
+                // which attaches -rc tags to the wrong commit during dev→stage runs
+                // and corrupts subsequent version calculations.
+                target_commitish:  headSha,
+                name:              version,
                 body,
-                draft:      true,
-                prerelease: isPrerelease,
+                draft:             true,
+                prerelease:        isPrerelease,
               });
-              core.info(`Created draft ${releaseType}: ${version}`);
+              core.info(`Created draft ${releaseType}: ${version} @ ${headSha}`);
             } catch (err) {
-              // Tag may already exist; log but don't fail the workflow.
+              // Tag may already exist (e.g. re-running the workflow). Log and continue.
               core.warning(`Could not create release draft for ${version}: ${err.message}`);
             }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,10 +3,11 @@ name: Claude Review
 # Runs an automated Claude Code review on pull requests that move code between
 # the two gated branch transitions in this repo:
 #
-#   dev  →  stage   (integration gate)
-#   stage →  main   (production gate)
+#   dev  →  stage   (pre-release integration gate)
+#   stage →  main   (production release gate)
 #
-# Feature-branch PRs are intentionally excluded to keep token usage low.
+# Feature-branch PRs are intentionally excluded to keep token usage low and
+# to make reviews meaningful — only gate-crossing transitions get reviewed.
 # Manual runs (workflow_dispatch) bypass the branch filter for testing.
 #
 # Required secret: CLAUDE_CODE_OAUTH_TOKEN (added automatically by the Claude GitHub App)
@@ -51,7 +52,6 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY:       ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          # Accept either the GitHub App OAuth token or a direct API key.
           if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
             echo "Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set."
             exit 1
@@ -78,35 +78,108 @@ jobs:
         if: steps.keycheck.outcome != 'success'
         run: exit 1
 
+      # ── Collect git context ────────────────────────────────────────────────
+      # Build a summary of commits and changed files since the base branch,
+      # so Claude can classify changes without having to run git itself.
+      - name: Collect git context
+        if: steps.keycheck.outcome == 'success'
+        id: gitctx
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Fetch the base branch so we can diff against it.
+          git fetch origin "$BASE_REF" --depth=100
+
+          BASE="origin/$BASE_REF"
+
+          # Commits unique to this PR (no merges, one-line summary).
+          COMMIT_LOG=$(git log "$BASE"...HEAD --oneline --no-merges | head -80)
+
+          # Files changed: status (A/M/D/R) + path.
+          CHANGED_FILES=$(git diff --name-status "$BASE"...HEAD | head -120)
+
+          # Diffstat (insertions/deletions per file).
+          DIFFSTAT=$(git diff --stat "$BASE"...HEAD | tail -5)
+
+          # Write to GITHUB_ENV using heredoc sentinels so newlines survive.
+          {
+            echo "COMMIT_LOG<<SENTINEL_CL"
+            echo "$COMMIT_LOG"
+            echo "SENTINEL_CL"
+            echo "CHANGED_FILES<<SENTINEL_CF"
+            echo "$CHANGED_FILES"
+            echo "SENTINEL_CF"
+            echo "DIFFSTAT<<SENTINEL_DS"
+            echo "$DIFFSTAT"
+            echo "SENTINEL_DS"
+          } >> "$GITHUB_ENV"
+
       # ── Build review prompt ────────────────────────────────────────────────
       - name: Build review prompt
         if: steps.keycheck.outcome == 'success'
         env:
-          BASE_REF:  ${{ github.base_ref }}
-          HEAD_REF:  ${{ github.head_ref }}
-          PR_TITLE:  ${{ github.event.pull_request.title }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF:      ${{ github.base_ref }}
+          HEAD_REF:      ${{ github.head_ref }}
+          PR_TITLE:      ${{ github.event.pull_request.title }}
+          PR_NUMBER:     ${{ github.event.pull_request.number }}
+          COMMIT_LOG:    ${{ env.COMMIT_LOG }}
+          CHANGED_FILES: ${{ env.CHANGED_FILES }}
+          DIFFSTAT:      ${{ env.DIFFSTAT }}
         run: |
           python3 - <<'PY'
           import os
           from pathlib import Path
 
-          base      = Path(".github/claude/prompts/review.md").read_text()
-          base_ref  = os.environ.get("BASE_REF",  "")
-          head_ref  = os.environ.get("HEAD_REF",  "")
-          pr_title  = os.environ.get("PR_TITLE",  "")
-          pr_number = os.environ.get("PR_NUMBER", "")
+          base_prompt  = Path(".github/claude/prompts/review.md").read_text()
+          base_ref     = os.environ.get("BASE_REF",      "")
+          head_ref     = os.environ.get("HEAD_REF",      "")
+          pr_title     = os.environ.get("PR_TITLE",      "")
+          pr_number    = os.environ.get("PR_NUMBER",     "")
+          commit_log   = os.environ.get("COMMIT_LOG",    "(none)")
+          changed_files= os.environ.get("CHANGED_FILES", "(none)")
+          diffstat     = os.environ.get("DIFFSTAT",      "(none)")
+
+          # Determine transition label for the prompt.
+          if base_ref == "stage":
+              transition_label = "dev → stage  (pre-release integration gate)"
+          elif base_ref == "main":
+              transition_label = "stage → main  (production release gate — highest scrutiny)"
+          else:
+              transition_label = f"{head_ref} → {base_ref}"
 
           prompt = "\n".join([
-              base,
+              base_prompt,
               "",
               "---",
               "",
-              f"You are reviewing **PR #{pr_number}: {pr_title}**",
-              f"This PR merges `{head_ref}` into `{base_ref}`.",
+              f"## This Review",
+              f"",
+              f"**PR #{pr_number}:** {pr_title}",
+              f"**Transition:** `{transition_label}`",
+              f"**Merging:** `{head_ref}` into `{base_ref}`",
+              "",
+              "### Commits in this PR",
+              "```",
+              commit_log or "(no commits found)",
+              "```",
+              "",
+              "### Files Changed",
+              "```",
+              changed_files or "(no files changed)",
+              "```",
+              "",
+              "### Diffstat",
+              "```",
+              diffstat or "(no diffstat available)",
+              "```",
+              "",
+              "---",
               "",
               "Use the Read, Glob, and Grep tools to inspect changed or related files as needed,",
               "then post your structured review as a single comment on this PR.",
+              "Fill in every section of the required output format — Breaking Changes,",
+              "Non-Breaking Changes, Environment & Config Impact, Ecosystem Effects,",
+              "Blocking Issues, Other Issues, and Suggested Tests.",
           ])
 
           github_env = os.environ.get("GITHUB_ENV", "")
@@ -122,7 +195,6 @@ jobs:
         if: steps.keycheck.outcome == 'success'
         uses: anthropics/claude-code-action@v1
         with:
-          # GitHub App OAuth token takes priority; falls back to direct API key.
           anthropic_api_key:       ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token:            ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,20 @@
 name: Release
 
+# Publishes a GitHub release when a version tag is pushed to `main`.
+#
+# The full structured changelog (breaking changes, environment impact, ecosystem
+# effects) is generated separately by claude-changelog.yml when stage is merged
+# into main. This workflow finalises the release draft created at that point.
+#
+# Tag format: v<major>.<minor>.<patch>  (e.g. v1.2.3)
+# Only tags on `main` are considered production releases.
+
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v[0-9]+.[0-9]+.[0-9]+"   # production releases only (no -rc, -beta, etc.)
+    branches:
+      - main                        # guard: only finalize on main
   workflow_dispatch:
 
 permissions:
@@ -11,10 +22,22 @@ permissions:
 
 jobs:
   release:
+    name: Publish Release
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
-      - name: Create GitHub release
+        with:
+          fetch-depth: 0
+
+      # If claude-changelog.yml already created a draft release for this tag,
+      # softprops/action-gh-release will update it; otherwise it creates a new one.
+      # The body is left empty here — the structured changelog body was written by
+      # the claude-changelog.yml step when stage was merged into main.
+      - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          # Do not overwrite body if a draft already exists with Claude's changelog.
+          generate_release_notes: false
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,10 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"   # production releases only (no -rc, -beta, etc.)
-    branches:
-      - main                        # guard: only finalize on main
+      # GitHub Actions uses glob syntax, not regex.
+      # v[0-9]* matches v1, v10, v100, etc. — no + operator.
+      # The job-level `if` below excludes pre-release tags (-rc, -beta, -alpha).
+      - "v[0-9]*.[0-9]*.[0-9]*"
   workflow_dispatch:
 
 permissions:
@@ -24,6 +25,10 @@ jobs:
   release:
     name: Publish Release
     runs-on: ubuntu-latest
+
+    # Exclude pre-release tags (v1.2.3-rc.1, v1.2.3-beta, etc.).
+    # Only bare semver tags like v1.2.3 reach this step.
+    if: "!contains(github.ref_name, '-')"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What changed

### New: `claude-changelog.yml`
- Fires **only** on merged PRs to `stage` (from `dev`) or `main` (from `stage`)
- Computes version label (rc for pre-release, patch bump for release)
- Collects git log + diffstat since previous tag
- Calls Claude with `Read/Glob/Grep` tools to classify every commit
- Posts structured changelog as a PR comment
- Creates a draft GitHub pre-release (dev→stage) or release (stage→main)

### New: `.github/claude/prompts/changelog.md`
Full classification schema for Claude:
- Breaking vs non-breaking changes
- Environment & Config Changes table (required vs optional with defaults)
- Ecosystem Effects (Go↔Python MCP contract, FPL API data deps, report formats)
- Deployment Checklist

### Updated: `claude-review.yml`
- Now collects `git log`, `git diff --name-status`, and `git diff --stat` since the base branch
- Passes all of this as structured context into the review prompt
- Determines transition label (`dev→stage` vs `stage→main`) and sets strictness in prompt

### Updated: `.github/claude/prompts/review.md`
- Added **Breaking Changes** section (required output)
- Added **Non-Breaking Changes** section
- Added **Environment & Config Impact** section
- Added **Ecosystem Effects** section (Go↔Python contract, FDR/waiver data deps)
- Table of strictness levels by transition
- Explicit list of files Claude should check for contract violations

### Updated: `release.yml`
- Restricted tag pattern to `vX.Y.Z` only (no `-rc`, `-beta`, etc.)
- Disabled `generate_release_notes: true` — body comes from `claude-changelog.yml` draft

## Why
The existing workflows had no structured way to distinguish breaking from non-breaking changes, no coverage of environment/config impact, and no pre-release vs release changelog. Gas Town polecats and human reviewers both need this context to make safe merge decisions.

## How to test
- Open a PR from `dev` → `stage` and verify `claude-review.yml` fires with structured output
- Merge a PR into `stage` and verify `claude-changelog.yml` creates a pre-release draft
- Merge a PR into `main` and verify a release draft is created
- `workflow_dispatch` on both workflows for manual testing

## Commands run
- No code changes — workflow and prompt files only

## Risks / Edge cases
- `claude-changelog.yml` uses `git describe --tags` — if no tags exist, falls back to first commit (safe)
- Version bump logic bumps patch only; for minor/major bumps, tag manually before merge
- `release.yml` will no longer auto-generate notes — Claude's changelog is the source of truth