### PR TITLE
fix(go): resolve writeLeagueDetails symbol collision + apply gofmt to transaction_analysis.go

### DIFF
--- a/apps/mcp-server/fpl-server/new_tools_test.go
+++ b/apps/mcp-server/fpl-server/new_tools_test.go
@@ -59,8 +59,8 @@ func writeGameJSON(t *testing.T, dir string, currentEvent int) {
 	writeJSON(t, filepath.Join(dir, "game", "game.json"), map[string]any{"current_event": currentEvent})
 }
 
-// writeLeagueDetails writes league/{leagueID}/details.json.
-func writeLeagueDetails(t *testing.T, dir string, leagueID int, entries []any, matches []any) {
+// writeLeagueDetailsFixture writes league/{leagueID}/details.json.
+func writeLeagueDetailsFixture(t *testing.T, dir string, leagueID int, entries []any, matches []any) {
 	t.Helper()
 	writeJSON(t, filepath.Join(dir, fmt.Sprintf("league/%d/details.json", leagueID)), map[string]any{
 		"league_entries": entries,
@@ -97,7 +97,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 26)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writePicks(t, dir, 200, 26, 15) // positions 1-15; 1-11=starters, 12-15=bench
 
 		entryID := 200
@@ -127,7 +127,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 26)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writePicks(t, dir, 200, 26, 1)
 
 		name := "Alpha FC"
@@ -147,7 +147,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 26)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writePicks(t, dir, 200, 26, 1)
 
 		name := "AFC" // short name for Alpha FC
@@ -170,7 +170,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 
 	t.Run("EntryNameNotFound", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		name := "Unknown FC"
 		_, err := buildCurrentRoster(cfg, CurrentRosterArgs{LeagueID: 100, EntryName: &name})
 		if err == nil {
@@ -180,7 +180,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 
 	t.Run("NoEntryIdentifier", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		_, err := buildCurrentRoster(cfg, CurrentRosterArgs{LeagueID: 100})
 		if err == nil {
 			t.Fatal("expected error when neither entry_id nor entry_name supplied")
@@ -288,7 +288,7 @@ func TestBuildHeadToHead(t *testing.T) {
 
 	t.Run("WDLAccumulation", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			// GW1: Alpha(le=1) vs Beta(le=2), Alpha wins 50-40.
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 50, "league_entry_2": 2, "league_entry_2_points": 40},
 			// GW2: Beta(le=2) vs Alpha(le=1), Alpha still wins 60-55 (Alpha is entry_2).
@@ -322,7 +322,7 @@ func TestBuildHeadToHead(t *testing.T) {
 	t.Run("ScoreAssignmentWhenAIsEntry2", func(t *testing.T) {
 		// Verify scores are correctly swapped when A is league_entry_2.
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			// Alpha (le=1) is entry_2 in this match (Beta is entry_1).
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 2, "league_entry_1_points": 40, "league_entry_2": 1, "league_entry_2_points": 70},
 		})
@@ -351,7 +351,7 @@ func TestBuildHeadToHead(t *testing.T) {
 	t.Run("ChronologicalSort", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		// Write matches intentionally out of order.
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			map[string]any{"event": 5, "finished": true, "league_entry_1": 1, "league_entry_1_points": 50, "league_entry_2": 2, "league_entry_2_points": 40},
 			map[string]any{"event": 2, "finished": true, "league_entry_1": 2, "league_entry_1_points": 60, "league_entry_2": 1, "league_entry_2_points": 55},
 			map[string]any{"event": 3, "finished": true, "league_entry_1": 1, "league_entry_1_points": 45, "league_entry_2": 2, "league_entry_2_points": 50},
@@ -371,7 +371,7 @@ func TestBuildHeadToHead(t *testing.T) {
 
 	t.Run("ResolveByName", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 60, "league_entry_2": 2, "league_entry_2_points": 50},
 		})
 		nameA, nameB := "Alpha FC", "Beta FC"
@@ -394,7 +394,7 @@ func TestBuildHeadToHead(t *testing.T) {
 
 	t.Run("EntryNameNotFound", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		name := "Unknown FC"
 		_, err := buildHeadToHead(cfg, HeadToHeadArgs{LeagueID: 100, EntryNameA: &name})
 		if err == nil {
@@ -404,7 +404,7 @@ func TestBuildHeadToHead(t *testing.T) {
 
 	t.Run("UnfinishedMatchNotCounted", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			// Unfinished — should not affect W/D/L record.
 			map[string]any{"event": 1, "finished": false, "league_entry_1": 1, "league_entry_1_points": 70, "league_entry_2": 2, "league_entry_2_points": 50},
 		})
@@ -432,7 +432,7 @@ func TestBuildManagerSeason(t *testing.T) {
 
 	t.Run("RecordHighLowAvg", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			// GW1: Alpha(le=1) wins 80-60.
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 80, "league_entry_2": 2, "league_entry_2_points": 60},
 			// GW2: Alpha(le=2) loses 70-45.
@@ -470,7 +470,7 @@ func TestBuildManagerSeason(t *testing.T) {
 	t.Run("ChronologicalSort", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		// Matches stored out of order.
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			map[string]any{"event": 5, "finished": true, "league_entry_1": 1, "league_entry_1_points": 60, "league_entry_2": 2, "league_entry_2_points": 50},
 			map[string]any{"event": 2, "finished": true, "league_entry_1": 1, "league_entry_1_points": 55, "league_entry_2": 2, "league_entry_2_points": 60},
 		})
@@ -488,7 +488,7 @@ func TestBuildManagerSeason(t *testing.T) {
 
 	t.Run("ResolveByName", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 70, "league_entry_2": 2, "league_entry_2_points": 50},
 		})
 		name := "Alpha FC"
@@ -504,7 +504,7 @@ func TestBuildManagerSeason(t *testing.T) {
 	t.Run("NoFinishedMatches", func(t *testing.T) {
 		// All high/low/avg fields should default to zero when no finished matches exist.
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		entryID := 200
 		out, err := buildManagerSeason(cfg, ManagerSeasonArgs{LeagueID: 100, EntryID: &entryID})
 		if err != nil {
@@ -525,7 +525,7 @@ func TestBuildManagerSeason(t *testing.T) {
 
 	t.Run("MissingEntryIdentifier", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		_, err := buildManagerSeason(cfg, ManagerSeasonArgs{LeagueID: 100})
 		if err == nil {
 			t.Fatal("expected error when neither entry_id nor entry_name supplied")
@@ -746,7 +746,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 	t.Run("FiltersUnapprovedTransactions", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				// Approved waiver → included.
@@ -771,7 +771,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 	t.Run("FreeAgentTransactionIncluded", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				// kind="f" (free agent) should be included.
@@ -791,7 +791,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 		// Add Salah (MID=3), drop Haaland (FWD=4).
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				map[string]any{"entry": 200, "element_in": 1, "element_out": 2, "event": 26, "kind": "f", "result": "a"},
@@ -816,7 +816,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 		// Salah added by both teams; Haaland added once.
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				map[string]any{"entry": 200, "element_in": 1, "element_out": 3, "event": 26, "kind": "w", "result": "a"},
@@ -842,7 +842,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 	t.Run("ManagerActivityGroupedByEntry", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				map[string]any{"entry": 200, "element_in": 1, "element_out": 2, "event": 26, "kind": "w", "result": "a"},

--- a/apps/mcp-server/fpl-server/transaction_analysis.go
+++ b/apps/mcp-server/fpl-server/transaction_analysis.go
@@ -75,12 +75,12 @@ func buildTransactionAnalysis(cfg ServerConfig, args TransactionAnalysisArgs) (T
 	}
 	var txResp struct {
 		Transactions []struct {
-			Entry     int    `json:"entry"`
-			ElementIn int    `json:"element_in"`
-			ElementOut int   `json:"element_out"`
-			Event     int    `json:"event"`
-			Kind      string `json:"kind"`
-			Result    string `json:"result"`
+			Entry      int    `json:"entry"`
+			ElementIn  int    `json:"element_in"`
+			ElementOut int    `json:"element_out"`
+			Event      int    `json:"event"`
+			Kind       string `json:"kind"`
+			Result     string `json:"result"`
 		} `json:"transactions"`
 	}
 	if err := json.Unmarshal(txRaw, &txResp); err != nil {


### PR DESCRIPTION
## What changed
- Renamed `writeLeagueDetails` → `writeLeagueDetailsFixture` in `new_tools_test.go` (1 declaration + 21 call sites) to resolve the symbol collision with the identically-named 4-param helper in `fpl_logic_test.go`
- Applied `gofmt -w` to `transaction_analysis.go` (whitespace/indent formatting only, no logic changes)

## Why
Both issues blocked every Go CI run:
1. The `writeLeagueDetails` redeclaration caused a hard compile error — `go test ./...` and `go vet ./...` could not run at all on `main`
2. `gofmt -l` flagged `transaction_analysis.go`, which would cause any Go PR's format check to fail

## How to test
```
cd apps/mcp-server
go fmt ./...         # no output (already clean)
go vet ./...         # exits 0
go test ./...        # fpl-server: ok
```

## Commands run
- `go test ./...` — PASS
- `go vet ./fpl-server/ ./internal/... ./cmd/...` — PASS
- `gofmt -l fpl-server/ internal/` — no output (clean)

## Risks / Edge cases
- No logic changes. Only test helper rename and whitespace formatting.
- `fpl_logic_test.go` is unchanged.
- All 22 renamed occurrences in `new_tools_test.go` were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)