### PR TITLE
fix(config): remove hardcoded LEAGUE_ID/ENTRY_ID defaults — raise on missing env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,13 +42,15 @@ GO_SERVER_CMD=go run ./apps/mcp-server/fpl-server --addr :8080 --path /mcp
 # ── FPL league identity ───────────────────────────────────────────────────────
 
 # Your FPL Draft league ID.  Find it in the URL when viewing your league on
-# draft.premierleague.com (e.g. /draft/league/14204/details → LEAGUE_ID=14204).
-LEAGUE_ID=14204
+# draft.premierleague.com (e.g. /draft/league/12345/details → LEAGUE_ID=12345).
+# REQUIRED — the server will refuse to start if this is unset.
+LEAGUE_ID=your-league-id
 
 # Your FPL Draft entry (team) ID.  Used for personalised reports such as waiver
 # recommendations and starting-XI advice.  Visible in the URL when viewing
-# your team (e.g. /draft/entry/286192/event/1).
-ENTRY_ID=286192
+# your team (e.g. /draft/entry/67890/event/1).
+# REQUIRED — the server will refuse to start if this is unset.
+ENTRY_ID=your-entry-id
 
 
 # ── Data cache / refresh ─────────────────────────────────────────────────────
@@ -57,7 +59,7 @@ ENTRY_ID=286192
 # it to the local data/ directory.  The backend runs this command on startup
 # (if CACHE_REFRESH_ON_START=true) and/or on a daily schedule.  Substitute
 # your league ID in the --league flag.
-CACHE_REFRESH_CMD=go run ./apps/mcp-server/cmd/dev --refresh=scheduled --refresh-now --league 14204
+CACHE_REFRESH_CMD=go run ./apps/mcp-server/cmd/dev --refresh=scheduled --refresh-now --league your-league-id
 
 # Run CACHE_REFRESH_CMD once immediately when the backend starts (default: true).
 # Useful in development so data is always fresh on restart.

--- a/apps/backend/tests/test_config.py
+++ b/apps/backend/tests/test_config.py
@@ -1,6 +1,8 @@
 import os
 
-from backend.config import Settings, _resolve_dir
+import pytest
+
+from backend.config import Settings, _require_int_env, _resolve_dir
 
 
 def test_resolve_dir_relative(tmp_path) -> None:
@@ -10,8 +12,43 @@ def test_resolve_dir_relative(tmp_path) -> None:
     assert rel_path == "reports"
 
 
-def test_settings_defaults_are_populated() -> None:
+def test_settings_defaults_are_populated(monkeypatch) -> None:
+    monkeypatch.setenv("LEAGUE_ID", "11111")
+    monkeypatch.setenv("ENTRY_ID", "22222")
     settings = Settings()
     assert settings.reports_dir
     assert settings.data_dir
     assert settings.web_dir
+    assert settings.league_id == 11111
+    assert settings.entry_id == 22222
+
+
+def test_settings_missing_league_id_raises(monkeypatch) -> None:
+    monkeypatch.delenv("LEAGUE_ID", raising=False)
+    monkeypatch.setenv("ENTRY_ID", "22222")
+    with pytest.raises(ValueError, match="LEAGUE_ID"):
+        Settings()
+
+
+def test_settings_missing_entry_id_raises(monkeypatch) -> None:
+    monkeypatch.setenv("LEAGUE_ID", "11111")
+    monkeypatch.delenv("ENTRY_ID", raising=False)
+    with pytest.raises(ValueError, match="ENTRY_ID"):
+        Settings()
+
+
+def test_require_int_env_valid(monkeypatch) -> None:
+    monkeypatch.setenv("_TEST_INT_VAR", "42")
+    assert _require_int_env("_TEST_INT_VAR") == 42
+
+
+def test_require_int_env_missing_raises(monkeypatch) -> None:
+    monkeypatch.delenv("_TEST_INT_VAR", raising=False)
+    with pytest.raises(ValueError, match="_TEST_INT_VAR.*required"):
+        _require_int_env("_TEST_INT_VAR")
+
+
+def test_require_int_env_non_integer_raises(monkeypatch) -> None:
+    monkeypatch.setenv("_TEST_INT_VAR", "notanint")
+    with pytest.raises(ValueError, match="must be an integer"):
+        _require_int_env("_TEST_INT_VAR")


### PR DESCRIPTION
## What changed
- Replaced hardcoded defaults `"14204"` (LEAGUE_ID) and `"286192"` (ENTRY_ID) in `config.py` with a `_require_int_env()` helper that raises `ValueError` at startup if the variable is unset or non-integer
- Added 5 new tests in `test_config.py` covering all validation paths; made the existing defaults test explicit with `monkeypatch`
- Updated `.env.example` to use placeholder text and mark both vars as REQUIRED

## Why
If `LEAGUE_ID` / `ENTRY_ID` were not set, the scheduler silently generated reports for league `14204` / manager `286192` (the original developer's IDs) with no warning. Any other user's deployment would return wrong data without any indication of misconfiguration.

Closes #25. Follows CLAUDE.md rule: *"Never hardcode league IDs, entry IDs, or element IDs in source code."*

## How to test
```bash
cd apps/backend
# With env vars set (normal path — from .env or environment):
PYTHONPATH=. pytest tests/test_config.py -v

# Verify missing var raises immediately:
PYTHONPATH=. python3 -c "
import os; os.environ.pop('LEAGUE_ID', None)
from backend.config import Settings; Settings()
"
# Expected: ValueError: LEAGUE_ID environment variable is required but not set.
```

## Commands run
- `pytest tests/` — 56 passed
- `ruff check .` — no issues

## Risks / Edge cases
- Existing deployments with a `.env` file containing both vars are unaffected
- Deployments that were accidentally using the hardcoded defaults will now fail loudly at startup — this is intentional and the correct behaviour
- `Settings(league_id=X, entry_id=Y)` (explicit args) bypasses the factory — test-friendly

🤖 Generated with [Claude Code](https://claude.com/claude-code)