### PR TITLE
fix(ci): wire head_sha through workflow_dispatch in claude-review.yml

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,6 +19,11 @@ on:
     # further restricts to the exact source→target pairs we care about.
     branches: [stage, main]
   workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Head commit SHA to check out (leave blank to use branch HEAD)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -40,7 +45,10 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          # PR triggers supply pull_request.head.sha (pinned to the reviewed commit).
+          # workflow_dispatch supplies inputs.head_sha when a specific commit is intended;
+          # falls back to github.sha (branch HEAD) for untargeted manual runs.
+          ref: ${{ github.event.pull_request.head.sha || inputs.head_sha || github.sha }}
           fetch-depth: 0
 
       # ── API key guard ──────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed
- Added optional `head_sha` input to the `workflow_dispatch` trigger in `claude-review.yml`
- Updated checkout `ref` to `pull_request.head.sha || inputs.head_sha || github.sha`

## Why
`workflow_dispatch` runs always silently checked out branch HEAD because `github.event.pull_request.head.sha` is `null` when there is no PR event. The checkout step fell back to branch HEAD with no warning, meaning backfill reruns or manual test runs could anchor to the wrong commit.

The three-part fallback makes intent explicit:
1. PR-triggered runs use `pull_request.head.sha` (pinned) — unchanged
2. Manual runs with an explicit SHA use `inputs.head_sha` — new, enables targeted reruns
3. Manual runs without a SHA use `github.sha` (branch HEAD) — same as current behaviour, now explicit

Closes #53. Supersedes the documentation-only PR #53.

## How to test
- Trigger `workflow_dispatch` with a specific `head_sha` and confirm the checkout step reports that SHA
- Trigger without `head_sha` and confirm it checks out branch HEAD (`github.sha`)
- Open a real PR to `stage` or `main` and confirm the existing PR-triggered path still works

## Commands run
- No code or test changes — workflow YAML only

## Risks / Edge cases
- If `inputs.head_sha` is provided but does not exist in the repo, checkout will fail with a clear error (correct behaviour)
- PR #52 also updates `claude-review.yml`; if that PR is merged first this fix will need a trivial rebase, but the changes are to different sections and should not conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)