### PR TITLE
test(go): add unit tests for internal/points, internal/ledger, internal/reconcile

### DIFF
--- a/apps/mcp-server/fpl-server/new_tools_test.go
+++ b/apps/mcp-server/fpl-server/new_tools_test.go
@@ -59,8 +59,8 @@ func writeGameJSON(t *testing.T, dir string, currentEvent int) {
 	writeJSON(t, filepath.Join(dir, "game", "game.json"), map[string]any{"current_event": currentEvent})
 }
 
-// writeLeagueDetails writes league/{leagueID}/details.json.
-func writeLeagueDetails(t *testing.T, dir string, leagueID int, entries []any, matches []any) {
+// writeLeagueDetailsFixture writes league/{leagueID}/details.json.
+func writeLeagueDetailsFixture(t *testing.T, dir string, leagueID int, entries []any, matches []any) {
 	t.Helper()
 	writeJSON(t, filepath.Join(dir, fmt.Sprintf("league/%d/details.json", leagueID)), map[string]any{
 		"league_entries": entries,
@@ -97,7 +97,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 26)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writePicks(t, dir, 200, 26, 15) // positions 1-15; 1-11=starters, 12-15=bench
 
 		entryID := 200
@@ -127,7 +127,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 26)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writePicks(t, dir, 200, 26, 1)
 
 		name := "Alpha FC"
@@ -147,7 +147,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 26)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writePicks(t, dir, 200, 26, 1)
 
 		name := "AFC" // short name for Alpha FC
@@ -170,7 +170,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 
 	t.Run("EntryNameNotFound", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		name := "Unknown FC"
 		_, err := buildCurrentRoster(cfg, CurrentRosterArgs{LeagueID: 100, EntryName: &name})
 		if err == nil {
@@ -180,7 +180,7 @@ func TestBuildCurrentRoster(t *testing.T) {
 
 	t.Run("NoEntryIdentifier", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		_, err := buildCurrentRoster(cfg, CurrentRosterArgs{LeagueID: 100})
 		if err == nil {
 			t.Fatal("expected error when neither entry_id nor entry_name supplied")
@@ -288,7 +288,7 @@ func TestBuildHeadToHead(t *testing.T) {
 
 	t.Run("WDLAccumulation", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			// GW1: Alpha(le=1) vs Beta(le=2), Alpha wins 50-40.
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 50, "league_entry_2": 2, "league_entry_2_points": 40},
 			// GW2: Beta(le=2) vs Alpha(le=1), Alpha still wins 60-55 (Alpha is entry_2).
@@ -322,7 +322,7 @@ func TestBuildHeadToHead(t *testing.T) {
 	t.Run("ScoreAssignmentWhenAIsEntry2", func(t *testing.T) {
 		// Verify scores are correctly swapped when A is league_entry_2.
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			// Alpha (le=1) is entry_2 in this match (Beta is entry_1).
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 2, "league_entry_1_points": 40, "league_entry_2": 1, "league_entry_2_points": 70},
 		})
@@ -351,7 +351,7 @@ func TestBuildHeadToHead(t *testing.T) {
 	t.Run("ChronologicalSort", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		// Write matches intentionally out of order.
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			map[string]any{"event": 5, "finished": true, "league_entry_1": 1, "league_entry_1_points": 50, "league_entry_2": 2, "league_entry_2_points": 40},
 			map[string]any{"event": 2, "finished": true, "league_entry_1": 2, "league_entry_1_points": 60, "league_entry_2": 1, "league_entry_2_points": 55},
 			map[string]any{"event": 3, "finished": true, "league_entry_1": 1, "league_entry_1_points": 45, "league_entry_2": 2, "league_entry_2_points": 50},
@@ -371,7 +371,7 @@ func TestBuildHeadToHead(t *testing.T) {
 
 	t.Run("ResolveByName", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 60, "league_entry_2": 2, "league_entry_2_points": 50},
 		})
 		nameA, nameB := "Alpha FC", "Beta FC"
@@ -394,7 +394,7 @@ func TestBuildHeadToHead(t *testing.T) {
 
 	t.Run("EntryNameNotFound", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		name := "Unknown FC"
 		_, err := buildHeadToHead(cfg, HeadToHeadArgs{LeagueID: 100, EntryNameA: &name})
 		if err == nil {
@@ -404,7 +404,7 @@ func TestBuildHeadToHead(t *testing.T) {
 
 	t.Run("UnfinishedMatchNotCounted", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			// Unfinished — should not affect W/D/L record.
 			map[string]any{"event": 1, "finished": false, "league_entry_1": 1, "league_entry_1_points": 70, "league_entry_2": 2, "league_entry_2_points": 50},
 		})
@@ -432,7 +432,7 @@ func TestBuildManagerSeason(t *testing.T) {
 
 	t.Run("RecordHighLowAvg", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			// GW1: Alpha(le=1) wins 80-60.
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 80, "league_entry_2": 2, "league_entry_2_points": 60},
 			// GW2: Alpha(le=2) loses 70-45.
@@ -470,7 +470,7 @@ func TestBuildManagerSeason(t *testing.T) {
 	t.Run("ChronologicalSort", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		// Matches stored out of order.
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			map[string]any{"event": 5, "finished": true, "league_entry_1": 1, "league_entry_1_points": 60, "league_entry_2": 2, "league_entry_2_points": 50},
 			map[string]any{"event": 2, "finished": true, "league_entry_1": 1, "league_entry_1_points": 55, "league_entry_2": 2, "league_entry_2_points": 60},
 		})
@@ -488,7 +488,7 @@ func TestBuildManagerSeason(t *testing.T) {
 
 	t.Run("ResolveByName", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, []any{
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
 			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 70, "league_entry_2": 2, "league_entry_2_points": 50},
 		})
 		name := "Alpha FC"
@@ -504,7 +504,7 @@ func TestBuildManagerSeason(t *testing.T) {
 	t.Run("NoFinishedMatches", func(t *testing.T) {
 		// All high/low/avg fields should default to zero when no finished matches exist.
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		entryID := 200
 		out, err := buildManagerSeason(cfg, ManagerSeasonArgs{LeagueID: 100, EntryID: &entryID})
 		if err != nil {
@@ -525,7 +525,7 @@ func TestBuildManagerSeason(t *testing.T) {
 
 	t.Run("MissingEntryIdentifier", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		_, err := buildManagerSeason(cfg, ManagerSeasonArgs{LeagueID: 100})
 		if err == nil {
 			t.Fatal("expected error when neither entry_id nor entry_name supplied")
@@ -746,7 +746,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 	t.Run("FiltersUnapprovedTransactions", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				// Approved waiver → included.
@@ -771,7 +771,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 	t.Run("FreeAgentTransactionIncluded", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				// kind="f" (free agent) should be included.
@@ -791,7 +791,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 		// Add Salah (MID=3), drop Haaland (FWD=4).
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				map[string]any{"entry": 200, "element_in": 1, "element_out": 2, "event": 26, "kind": "f", "result": "a"},
@@ -816,7 +816,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 		// Salah added by both teams; Haaland added once.
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				map[string]any{"entry": 200, "element_in": 1, "element_out": 3, "event": 26, "kind": "w", "result": "a"},
@@ -842,7 +842,7 @@ func TestBuildTransactionAnalysis(t *testing.T) {
 	t.Run("ManagerActivityGroupedByEntry", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
-		writeLeagueDetails(t, dir, 100, twoEntries, nil)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, nil)
 		writeJSON(t, filepath.Join(dir, "league/100/transactions.json"), map[string]any{
 			"transactions": []any{
 				map[string]any{"entry": 200, "element_in": 1, "element_out": 2, "event": 26, "kind": "w", "result": "a"},

--- a/apps/mcp-server/internal/ledger/ledger_test.go
+++ b/apps/mcp-server/internal/ledger/ledger_test.go
@@ -1,0 +1,219 @@
+package ledger
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// BuildDraftLedger
+// ---------------------------------------------------------------------------
+
+func TestBuildDraftLedger_Empty(t *testing.T) {
+	ledger := BuildDraftLedger(1, nil)
+
+	if ledger.LeagueID != 1 {
+		t.Errorf("LeagueID = %d, want 1", ledger.LeagueID)
+	}
+	if len(ledger.Managers) != 0 {
+		t.Errorf("Managers len = %d, want 0", len(ledger.Managers))
+	}
+	if len(ledger.Squads) != 0 {
+		t.Errorf("Squads len = %d, want 0", len(ledger.Squads))
+	}
+	if len(ledger.Picks) != 0 {
+		t.Errorf("Picks len = %d, want 0", len(ledger.Picks))
+	}
+}
+
+func TestBuildDraftLedger_SortsByIndex(t *testing.T) {
+	choices := []DraftChoice{
+		{Entry: 1, EntryName: "Alpha", Element: 10, Round: 1, Pick: 1, Index: 3},
+		{Entry: 2, EntryName: "Beta", Element: 20, Round: 1, Pick: 2, Index: 1},
+		{Entry: 1, EntryName: "Alpha", Element: 30, Round: 2, Pick: 3, Index: 5},
+		{Entry: 2, EntryName: "Beta", Element: 40, Round: 2, Pick: 4, Index: 2},
+	}
+
+	l := BuildDraftLedger(10, choices)
+
+	// Picks must be in ascending Index order.
+	for i := 1; i < len(l.Picks); i++ {
+		if l.Picks[i].Index < l.Picks[i-1].Index {
+			t.Errorf("Picks not sorted by index at position %d: %d < %d",
+				i, l.Picks[i].Index, l.Picks[i-1].Index)
+		}
+	}
+}
+
+func TestBuildDraftLedger_ManagersDeduplicatedAndSorted(t *testing.T) {
+	choices := []DraftChoice{
+		{Entry: 5, EntryName: "Five", Element: 50, Index: 1},
+		{Entry: 3, EntryName: "Three", Element: 30, Index: 2},
+		{Entry: 5, EntryName: "Five", Element: 55, Index: 3}, // duplicate entry
+	}
+
+	l := BuildDraftLedger(1, choices)
+
+	if len(l.Managers) != 2 {
+		t.Errorf("Managers len = %d, want 2 (duplicate entry deduplicated)", len(l.Managers))
+	}
+	// Sorted by EntryID ascending.
+	if l.Managers[0].EntryID != 3 || l.Managers[1].EntryID != 5 {
+		t.Errorf("Managers not sorted: got %v %v", l.Managers[0], l.Managers[1])
+	}
+}
+
+func TestBuildDraftLedger_SquadsAggregatePerEntry(t *testing.T) {
+	choices := []DraftChoice{
+		{Entry: 1, EntryName: "A", Element: 10, Index: 1},
+		{Entry: 2, EntryName: "B", Element: 20, Index: 2},
+		{Entry: 1, EntryName: "A", Element: 30, Index: 3},
+	}
+
+	l := BuildDraftLedger(1, choices)
+
+	squadByEntry := make(map[int][]int)
+	for _, s := range l.Squads {
+		squadByEntry[s.EntryID] = s.PlayerIDs
+	}
+
+	if len(squadByEntry[1]) != 2 {
+		t.Errorf("Entry 1 squad len = %d, want 2", len(squadByEntry[1]))
+	}
+	if len(squadByEntry[2]) != 1 {
+		t.Errorf("Entry 2 squad len = %d, want 1", len(squadByEntry[2]))
+	}
+}
+
+func TestBuildDraftLedger_SquadsSortedByEntryID(t *testing.T) {
+	choices := []DraftChoice{
+		{Entry: 9, EntryName: "Nine", Element: 90, Index: 1},
+		{Entry: 2, EntryName: "Two", Element: 20, Index: 2},
+	}
+
+	l := BuildDraftLedger(1, choices)
+
+	if l.Squads[0].EntryID != 2 || l.Squads[1].EntryID != 9 {
+		t.Errorf("Squads not sorted by EntryID: %v", l.Squads)
+	}
+}
+
+func TestBuildDraftLedger_PicksPreserveFields(t *testing.T) {
+	choices := []DraftChoice{
+		{Entry: 1, EntryName: "A", Element: 10, Round: 2, Pick: 7, Index: 4,
+			ChoiceTime: "2024-08-01T10:00:00Z", WasAuto: true, League: 99},
+	}
+
+	l := BuildDraftLedger(99, choices)
+
+	if len(l.Picks) != 1 {
+		t.Fatalf("Picks len = %d, want 1", len(l.Picks))
+	}
+	p := l.Picks[0]
+	if p.EntryID != 1 || p.Element != 10 || p.Round != 2 ||
+		p.Pick != 7 || p.Index != 4 || p.ChoiceTime != "2024-08-01T10:00:00Z" || !p.WasAuto {
+		t.Errorf("Pick fields not preserved: %+v", p)
+	}
+}
+
+func TestBuildDraftLedger_GeneratedAtUTCIsRFC3339(t *testing.T) {
+	l := BuildDraftLedger(1, nil)
+	if _, err := time.Parse(time.RFC3339, l.GeneratedAtUTC); err != nil {
+		t.Errorf("GeneratedAtUTC %q is not RFC3339: %v", l.GeneratedAtUTC, err)
+	}
+}
+
+func TestWriteDraftLedger(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "ledger.json")
+
+	choices := []DraftChoice{
+		{Entry: 1, EntryName: "A", Element: 10, Index: 1},
+	}
+	l := BuildDraftLedger(1, choices)
+
+	if err := WriteDraftLedger(path, l); err != nil {
+		t.Fatalf("WriteDraftLedger error: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	if !strings.Contains(string(b), `"league_id"`) {
+		t.Error("output missing league_id key")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuildEntrySnapshot
+// ---------------------------------------------------------------------------
+
+func TestBuildEntrySnapshot_FieldsPreserved(t *testing.T) {
+	raw := EntryEventRaw{
+		EntryHistory: json.RawMessage(`{"total_points":120}`),
+		Picks: []EntryPick{
+			{Element: 5, Position: 1, Multiplier: 2, IsCaptain: true},
+			{Element: 9, Position: 3, Multiplier: 1},
+		},
+		Subs: []EntrySub{
+			{ElementIn: 7, ElementOut: 5, Event: 3},
+		},
+	}
+
+	snap := BuildEntrySnapshot(10, 20, 3, raw)
+
+	if snap.LeagueID != 10 || snap.EntryID != 20 || snap.Gameweek != 3 {
+		t.Errorf("IDs not propagated: league=%d entry=%d gw=%d", snap.LeagueID, snap.EntryID, snap.Gameweek)
+	}
+	if len(snap.Picks) != 2 {
+		t.Errorf("Picks len = %d, want 2", len(snap.Picks))
+	}
+	if len(snap.Subs) != 1 {
+		t.Errorf("Subs len = %d, want 1", len(snap.Subs))
+	}
+	if string(snap.EntryHistory) != `{"total_points":120}` {
+		t.Errorf("EntryHistory not preserved: %s", snap.EntryHistory)
+	}
+}
+
+func TestBuildEntrySnapshot_GeneratedAtUTCIsRFC3339(t *testing.T) {
+	snap := BuildEntrySnapshot(1, 1, 1, EntryEventRaw{})
+	if _, err := time.Parse(time.RFC3339, snap.GeneratedAtUTC); err != nil {
+		t.Errorf("GeneratedAtUTC %q is not RFC3339: %v", snap.GeneratedAtUTC, err)
+	}
+}
+
+func TestBuildEntrySnapshot_EmptyPicksAndSubs(t *testing.T) {
+	snap := BuildEntrySnapshot(1, 1, 1, EntryEventRaw{})
+	if snap.Picks != nil {
+		t.Errorf("Picks should be nil for empty raw, got %v", snap.Picks)
+	}
+	if snap.Subs != nil {
+		t.Errorf("Subs should be nil for empty raw, got %v", snap.Subs)
+	}
+}
+
+func TestWriteEntrySnapshot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "snapshot.json")
+
+	raw := EntryEventRaw{
+		Picks: []EntryPick{{Element: 1, Position: 1, Multiplier: 1}},
+	}
+	snap := BuildEntrySnapshot(1, 2, 3, raw)
+
+	if err := WriteEntrySnapshot(path, snap); err != nil {
+		t.Fatalf("WriteEntrySnapshot error: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	if !strings.Contains(string(b), `"entry_id"`) {
+		t.Error("output missing entry_id key")
+	}
+}

--- a/apps/mcp-server/internal/points/points_test.go
+++ b/apps/mcp-server/internal/points/points_test.go
@@ -1,0 +1,192 @@
+package points
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aatrey56/FPL-Draft-Agent/apps/mcp-server/internal/ledger"
+)
+
+// makeSnap builds a minimal EntrySnapshot from a slice of (element, position, multiplier) triples.
+func makeSnap(picks ...struct{ elem, pos, mult int }) *ledger.EntrySnapshot {
+	ps := make([]ledger.EntryPick, 0, len(picks))
+	for _, p := range picks {
+		ps = append(ps, ledger.EntryPick{
+			Element:    p.elem,
+			Position:   p.pos,
+			Multiplier: p.mult,
+		})
+	}
+	return &ledger.EntrySnapshot{Picks: ps}
+}
+
+func TestBuildResult_BasicPoints(t *testing.T) {
+	snap := makeSnap(
+		struct{ elem, pos, mult int }{10, 1, 1},
+		struct{ elem, pos, mult int }{20, 2, 1},
+	)
+	live := map[int]LiveStats{
+		10: {Minutes: 90, TotalPoints: 6},
+		20: {Minutes: 90, TotalPoints: 4},
+	}
+
+	r := BuildResult(1, 2, 3, snap, live)
+
+	if r.TotalPoints != 10 {
+		t.Errorf("TotalPoints = %d, want 10", r.TotalPoints)
+	}
+	if len(r.Players) != 2 {
+		t.Errorf("Players len = %d, want 2", len(r.Players))
+	}
+}
+
+func TestBuildResult_CaptainDoubles(t *testing.T) {
+	// Captain has multiplier 2 — his points should be doubled.
+	snap := makeSnap(
+		struct{ elem, pos, mult int }{10, 1, 2}, // captain
+		struct{ elem, pos, mult int }{20, 2, 1},
+	)
+	live := map[int]LiveStats{
+		10: {Minutes: 90, TotalPoints: 6},
+		20: {Minutes: 90, TotalPoints: 3},
+	}
+
+	r := BuildResult(1, 1, 1, snap, live)
+
+	// Captain: 6*2=12, other: 3*1=3, total=15
+	if r.TotalPoints != 15 {
+		t.Errorf("TotalPoints = %d, want 15 (captain doubled)", r.TotalPoints)
+	}
+	// Verify the captain's individual entry
+	for _, p := range r.Players {
+		if p.Element == 10 && p.Total != 12 {
+			t.Errorf("Captain Total = %d, want 12", p.Total)
+		}
+	}
+}
+
+func TestBuildResult_BenchPlayersExcluded(t *testing.T) {
+	// Positions 12–15 are bench and must not contribute to total.
+	snap := makeSnap(
+		struct{ elem, pos, mult int }{10, 1, 1},
+		struct{ elem, pos, mult int }{99, 12, 1}, // bench — excluded
+	)
+	live := map[int]LiveStats{
+		10: {Minutes: 90, TotalPoints: 6},
+		99: {Minutes: 90, TotalPoints: 8}, // bench player scored big — must not count
+	}
+
+	r := BuildResult(1, 1, 1, snap, live)
+
+	if r.TotalPoints != 6 {
+		t.Errorf("TotalPoints = %d, want 6 (bench excluded)", r.TotalPoints)
+	}
+	if len(r.Players) != 1 {
+		t.Errorf("Players len = %d, want 1 (only starters)", len(r.Players))
+	}
+}
+
+func TestBuildResult_MissingLiveStats(t *testing.T) {
+	// If no live stats exist for a player, treat as 0 points.
+	snap := makeSnap(
+		struct{ elem, pos, mult int }{10, 1, 1},
+		struct{ elem, pos, mult int }{20, 2, 1},
+	)
+	live := map[int]LiveStats{
+		10: {Minutes: 90, TotalPoints: 5},
+		// 20 is absent — should default to 0
+	}
+
+	r := BuildResult(1, 1, 1, snap, live)
+
+	if r.TotalPoints != 5 {
+		t.Errorf("TotalPoints = %d, want 5 (missing stats = 0)", r.TotalPoints)
+	}
+}
+
+func TestBuildResult_EmptyPicks(t *testing.T) {
+	snap := &ledger.EntrySnapshot{Picks: []ledger.EntryPick{}}
+	r := BuildResult(1, 1, 1, snap, map[int]LiveStats{})
+
+	if r.TotalPoints != 0 {
+		t.Errorf("TotalPoints = %d, want 0 for empty picks", r.TotalPoints)
+	}
+	if len(r.Players) != 0 {
+		t.Errorf("Players len = %d, want 0", len(r.Players))
+	}
+}
+
+func TestBuildResult_CaptainZeroPoints(t *testing.T) {
+	// Captain scores 0 — doubled 0 is still 0.
+	snap := makeSnap(
+		struct{ elem, pos, mult int }{10, 1, 2}, // captain
+	)
+	live := map[int]LiveStats{
+		10: {Minutes: 0, TotalPoints: 0},
+	}
+
+	r := BuildResult(1, 1, 1, snap, live)
+
+	if r.TotalPoints != 0 {
+		t.Errorf("TotalPoints = %d, want 0 (captain 0 * 2 = 0)", r.TotalPoints)
+	}
+}
+
+func TestBuildResult_FieldsPopulated(t *testing.T) {
+	snap := makeSnap(struct{ elem, pos, mult int }{10, 1, 1})
+	live := map[int]LiveStats{10: {Minutes: 45, TotalPoints: 2}}
+
+	r := BuildResult(42, 99, 7, snap, live)
+
+	if r.LeagueID != 42 {
+		t.Errorf("LeagueID = %d, want 42", r.LeagueID)
+	}
+	if r.EntryID != 99 {
+		t.Errorf("EntryID = %d, want 99", r.EntryID)
+	}
+	if r.Gameweek != 7 {
+		t.Errorf("Gameweek = %d, want 7", r.Gameweek)
+	}
+	if r.GeneratedAtUTC == "" {
+		t.Error("GeneratedAtUTC should not be empty")
+	}
+}
+
+func TestBuildResult_AllPositions11Included(t *testing.T) {
+	// Position == 11 is still a starter and must be included.
+	snap := makeSnap(struct{ elem, pos, mult int }{11, 11, 1})
+	live := map[int]LiveStats{11: {Minutes: 90, TotalPoints: 3}}
+
+	r := BuildResult(1, 1, 1, snap, live)
+
+	if r.TotalPoints != 3 {
+		t.Errorf("TotalPoints = %d, want 3 (position 11 is a starter)", r.TotalPoints)
+	}
+}
+
+func TestWriteResult(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "result.json")
+
+	snap := makeSnap(struct{ elem, pos, mult int }{10, 1, 1})
+	live := map[int]LiveStats{10: {TotalPoints: 5}}
+	r := BuildResult(1, 1, 1, snap, live)
+
+	if err := WriteResult(path, r); err != nil {
+		t.Fatalf("WriteResult error: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	content := string(b)
+	if !strings.Contains(content, `"total_points"`) {
+		t.Error("output JSON missing total_points key")
+	}
+	if !strings.HasSuffix(strings.TrimRight(content, "\n"), "}") {
+		t.Error("output JSON should end with }")
+	}
+}

--- a/apps/mcp-server/internal/reconcile/reconcile_test.go
+++ b/apps/mcp-server/internal/reconcile/reconcile_test.go
@@ -1,0 +1,329 @@
+package reconcile
+
+import (
+	"testing"
+
+	"github.com/aatrey56/FPL-Draft-Agent/apps/mcp-server/internal/ledger"
+	"github.com/aatrey56/FPL-Draft-Agent/apps/mcp-server/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func makeLedger(squads ...struct {
+	entryID   int
+	playerIDs []int
+}) *model.DraftLedger {
+	s := make([]model.Squad, 0, len(squads))
+	for _, sq := range squads {
+		s = append(s, model.Squad{EntryID: sq.entryID, PlayerIDs: sq.playerIDs})
+	}
+	return &model.DraftLedger{Squads: s}
+}
+
+func makeWaiverTx(id, entry, elementIn, elementOut, event int) Transaction {
+	return Transaction{
+		ID:         id,
+		Entry:      entry,
+		ElementIn:  elementIn,
+		ElementOut: elementOut,
+		Event:      event,
+		Kind:       "w",
+		Result:     "a", // accepted
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuildOwnershipMap
+// ---------------------------------------------------------------------------
+
+func TestBuildOwnershipMap_Empty(t *testing.T) {
+	l := makeLedger()
+	m := BuildOwnershipMap(l)
+	if len(m) != 0 {
+		t.Errorf("map len = %d, want 0", len(m))
+	}
+}
+
+func TestBuildOwnershipMap_SingleEntry(t *testing.T) {
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10, 20, 30}})
+
+	m := BuildOwnershipMap(l)
+
+	if !m[1][10] || !m[1][20] || !m[1][30] {
+		t.Error("entry 1 should own players 10, 20, 30")
+	}
+	if m[1][99] {
+		t.Error("entry 1 should not own player 99")
+	}
+}
+
+func TestBuildOwnershipMap_MultipleEntries(t *testing.T) {
+	l := makeLedger(
+		struct {
+			entryID   int
+			playerIDs []int
+		}{1, []int{10, 20}},
+		struct {
+			entryID   int
+			playerIDs []int
+		}{2, []int{30, 40}},
+	)
+
+	m := BuildOwnershipMap(l)
+
+	if m[1][30] {
+		t.Error("entry 1 should not own player 30 (belongs to entry 2)")
+	}
+	if !m[2][30] || !m[2][40] {
+		t.Error("entry 2 should own players 30 and 40")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuildOwnershipMapAtGW
+// ---------------------------------------------------------------------------
+
+func TestBuildOwnershipMapAtGW_NoTransactions(t *testing.T) {
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10, 20}})
+
+	m := BuildOwnershipMapAtGW(l, nil, nil, 5)
+
+	if !m[1][10] || !m[1][20] {
+		t.Error("without transactions, ownership should match draft-day ledger")
+	}
+}
+
+func TestBuildOwnershipMapAtGW_WaiverApplied(t *testing.T) {
+	// Entry 1 drops player 10, adds player 99 in GW 3.
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10, 20}})
+	txs := []Transaction{makeWaiverTx(1, 1, 99, 10, 3)}
+
+	m := BuildOwnershipMapAtGW(l, txs, nil, 5)
+
+	if m[1][10] {
+		t.Error("player 10 should have been dropped by entry 1")
+	}
+	if !m[1][99] {
+		t.Error("player 99 should have been added by entry 1")
+	}
+	if !m[1][20] {
+		t.Error("player 20 should still be owned by entry 1")
+	}
+}
+
+func TestBuildOwnershipMapAtGW_FutureTransactionIgnored(t *testing.T) {
+	// Transaction in GW 10 — querying at GW 5 should not apply it.
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10, 20}})
+	txs := []Transaction{makeWaiverTx(1, 1, 99, 10, 10)} // future GW
+
+	m := BuildOwnershipMapAtGW(l, txs, nil, 5)
+
+	if !m[1][10] {
+		t.Error("player 10 should still be owned — GW 10 transaction should not apply at GW 5")
+	}
+	if m[1][99] {
+		t.Error("player 99 should not be added — GW 10 transaction should not apply at GW 5")
+	}
+}
+
+func TestBuildOwnershipMapAtGW_NonAcceptedTransactionIgnored(t *testing.T) {
+	// Only accepted (Result="a") transactions should be applied.
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10, 20}})
+	txs := []Transaction{{
+		ID: 1, Entry: 1, ElementIn: 99, ElementOut: 10, Event: 3,
+		Kind: "w", Result: "n", // NOT accepted
+	}}
+
+	m := BuildOwnershipMapAtGW(l, txs, nil, 5)
+
+	if !m[1][10] {
+		t.Error("player 10 should still be owned — rejected transaction must not apply")
+	}
+	if m[1][99] {
+		t.Error("player 99 should not be added — rejected transaction must not apply")
+	}
+}
+
+func TestBuildOwnershipMapAtGW_TradeApplied(t *testing.T) {
+	// Entry 1 and entry 2 trade: entry 1 gives player 20, receives player 30.
+	l := makeLedger(
+		struct {
+			entryID   int
+			playerIDs []int
+		}{1, []int{10, 20}},
+		struct {
+			entryID   int
+			playerIDs []int
+		}{2, []int{30, 40}},
+	)
+	trades := []Trade{
+		{
+			ID:            1,
+			OfferedEntry:  1,
+			ReceivedEntry: 2,
+			Event:         2,
+			State:         "p", // processed/accepted
+			ResponseTime:  "2024-09-01T10:00:00Z",
+			TradeItems: []TradeItem{
+				{ElementOut: 20, ElementIn: 30},
+			},
+		},
+	}
+
+	m := BuildOwnershipMapAtGW(l, nil, trades, 5)
+
+	// Entry 1 should own 10 (unchanged) and 30 (received), not 20 (given away).
+	if !m[1][10] {
+		t.Error("entry 1 should still own player 10")
+	}
+	if !m[1][30] {
+		t.Error("entry 1 should now own player 30 (received in trade)")
+	}
+	if m[1][20] {
+		t.Error("entry 1 should no longer own player 20 (given away in trade)")
+	}
+	// Entry 2 should own 40 (unchanged) and 20 (received), not 30 (given away).
+	if !m[2][20] {
+		t.Error("entry 2 should now own player 20 (received in trade)")
+	}
+	if m[2][30] {
+		t.Error("entry 2 should no longer own player 30 (given away in trade)")
+	}
+}
+
+func TestBuildOwnershipMapAtGW_FutureTradeIgnored(t *testing.T) {
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10, 20}}, struct {
+		entryID   int
+		playerIDs []int
+	}{2, []int{30}})
+
+	trades := []Trade{{
+		ID: 1, OfferedEntry: 1, ReceivedEntry: 2,
+		Event: 10, State: "p", ResponseTime: "2024-10-01T00:00:00Z",
+		TradeItems: []TradeItem{{ElementOut: 20, ElementIn: 30}},
+	}}
+
+	m := BuildOwnershipMapAtGW(l, nil, trades, 5)
+
+	if !m[1][20] {
+		t.Error("player 20 should still be owned by entry 1 (trade is in a future GW)")
+	}
+}
+
+func TestBuildOwnershipMapAtGW_TransactionsAppliedInOrder(t *testing.T) {
+	// Two sequential waivers for the same entry — order must be respected.
+	// GW 2: entry 1 drops 10, adds 50.
+	// GW 3: entry 1 drops 50, adds 70.
+	// At GW 5: entry 1 should own 20, 70 (not 10 or 50).
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10, 20}})
+	txs := []Transaction{
+		makeWaiverTx(1, 1, 50, 10, 2),
+		makeWaiverTx(2, 1, 70, 50, 3),
+	}
+
+	m := BuildOwnershipMapAtGW(l, txs, nil, 5)
+
+	if m[1][10] {
+		t.Error("player 10 should have been dropped in GW 2")
+	}
+	if m[1][50] {
+		t.Error("player 50 should have been dropped in GW 3")
+	}
+	if !m[1][70] {
+		t.Error("player 70 should have been added in GW 3")
+	}
+	if !m[1][20] {
+		t.Error("player 20 should still be owned")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuildReport
+// ---------------------------------------------------------------------------
+
+func TestBuildReport_MissingSnapshot(t *testing.T) {
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10}})
+
+	report := BuildReport(1, 3, l, nil, nil, map[int]*ledger.EntrySnapshot{}, []int{1})
+
+	if len(report.Entries) != 1 {
+		t.Fatalf("Entries len = %d, want 1", len(report.Entries))
+	}
+	if !report.Entries[0].MissingSnapshot {
+		t.Error("entry with no snapshot should have MissingSnapshot=true")
+	}
+}
+
+func TestBuildReport_CleanRoster_NoMismatch(t *testing.T) {
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10, 20}})
+
+	snap := &ledger.EntrySnapshot{
+		EntryID:  1,
+		Gameweek: 3,
+		Picks: []ledger.EntryPick{
+			{Element: 10, Position: 1},
+			{Element: 20, Position: 2},
+		},
+	}
+
+	report := BuildReport(1, 3, l, nil, nil, map[int]*ledger.EntrySnapshot{1: snap}, []int{1})
+
+	if len(report.Entries) != 0 {
+		t.Errorf("Entries len = %d, want 0 (no mismatches)", len(report.Entries))
+	}
+}
+
+func TestBuildReport_UnownedPlayerDetected(t *testing.T) {
+	// Entry 1 owns [10] at draft. Snapshot shows player 99 in lineup (never owned).
+	l := makeLedger(struct {
+		entryID   int
+		playerIDs []int
+	}{1, []int{10}})
+
+	snap := &ledger.EntrySnapshot{
+		EntryID:  1,
+		Gameweek: 3,
+		Picks: []ledger.EntryPick{
+			{Element: 10, Position: 1},
+			{Element: 99, Position: 2}, // not owned
+		},
+	}
+
+	report := BuildReport(1, 3, l, nil, nil, map[int]*ledger.EntrySnapshot{1: snap}, []int{1})
+
+	if len(report.Entries) != 1 {
+		t.Fatalf("Entries len = %d, want 1 (mismatch)", len(report.Entries))
+	}
+	if len(report.Entries[0].NotOwned) != 1 || report.Entries[0].NotOwned[0] != 99 {
+		t.Errorf("NotOwned = %v, want [99]", report.Entries[0].NotOwned)
+	}
+}


### PR DESCRIPTION
## What changed
Added 32 new unit tests across three previously uncovered `internal/` packages:

| Package | Tests | Coverage added |
|---|---|---|
| `internal/points` | 9 | `BuildResult` (captain multiplier, bench exclusion, missing stats, empty picks, field propagation), `WriteResult` |
| `internal/ledger` | 10 | `BuildDraftLedger` (empty, sort-by-index, manager dedup, squad aggregation, sort, field preservation, RFC3339), `BuildEntrySnapshot` (fields, timestamp, empty), `WriteXxx` disk round-trips |
| `internal/reconcile` | 13 | `BuildOwnershipMap` (empty, single, multi), `BuildOwnershipMapAtGW` (waiver apply, future tx ignored, rejected tx ignored, trade apply, future trade ignored, sequential order), `BuildReport` (missing snapshot, clean roster, unowned player) |

Also includes the cherry-picked `writeLeagueDetails` fix (already in PR #56) to allow the `fpl-server` package to build on this branch.

## Why
All seven `internal/` packages had zero test files. The three packages addressed here contain the most logic-dense pure functions — point scoring with multipliers, draft ledger construction, and ownership reconciliation after transactions/trades. These are business-critical code paths with no safety net.

## How to test
```bash
cd apps/mcp-server
go test ./internal/points/... ./internal/ledger/... ./internal/reconcile/... -v
go test ./...   # full suite
```

## Commands run
- `go test ./...` — all packages pass (fpl-server: ok, ledger: ok, points: ok, reconcile: ok)
- `go vet ./internal/...` — clean
- `gofmt -l ./internal/` — no output (clean)

## Risks / Edge cases
- No live API calls — all test state constructed inline
- `WriteXxx` tests use `t.TempDir()` — no disk pollution
- The cherry-picked `writeLeagueDetails` fix will become a no-op once PR #56 merges into `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)