### PR TITLE
fix: NaN/Inf guard, safe int parsing, asyncio deprecation, MaxInt32 sentinel

### DIFF
--- a/apps/backend/tests/test_server.py
+++ b/apps/backend/tests/test_server.py
@@ -1,0 +1,179 @@
+"""Tests for backend.server — run_report input validation and _parse_chat_payload."""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Stub heavy optional dependencies before any backend module is imported.
+# ---------------------------------------------------------------------------
+for _mod in ("requests", "openai", "apscheduler", "apscheduler.schedulers.background",
+             "apscheduler.triggers.cron"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+_apscheduler_bg = sys.modules["apscheduler.schedulers.background"]
+if not hasattr(_apscheduler_bg, "BackgroundScheduler"):
+    _apscheduler_bg.BackgroundScheduler = MagicMock  # type: ignore[attr-defined]
+
+_apscheduler_cron = sys.modules["apscheduler.triggers.cron"]
+if not hasattr(_apscheduler_cron, "CronTrigger"):
+    _apscheduler_cron.CronTrigger = MagicMock  # type: ignore[attr-defined]
+
+sys.modules["openai"].OpenAI = MagicMock  # type: ignore[attr-defined]
+
+# Provide a ZoneInfo stub (Python 3.9+ ships it, but ensure it exists).
+if "zoneinfo" not in sys.modules:
+    _zi = types.ModuleType("zoneinfo")
+    _zi.ZoneInfo = MagicMock  # type: ignore[attr-defined]
+    sys.modules["zoneinfo"] = _zi
+
+
+def _identity_decorator(*args, **kwargs):
+    """Return the decorated function unchanged — used to neuter FastAPI app.post/get/websocket."""
+    def _decorator(fn):
+        return fn
+    return _decorator
+
+
+# Build a minimal FastAPI stub that does NOT wrap decorated functions with MagicMock.
+_fastapi_app_stub = MagicMock()
+_fastapi_app_stub.post.side_effect = _identity_decorator
+_fastapi_app_stub.get.side_effect = _identity_decorator
+_fastapi_app_stub.websocket.side_effect = _identity_decorator
+_fastapi_app_stub.add_middleware.return_value = None
+_fastapi_app_stub.mount.return_value = None
+
+_fastapi_cls = MagicMock(return_value=_fastapi_app_stub)
+
+_fastapi_mod = types.ModuleType("fastapi")
+_fastapi_mod.FastAPI = _fastapi_cls  # type: ignore[attr-defined]
+_fastapi_mod.WebSocket = MagicMock  # type: ignore[attr-defined]
+
+_fastapi_middleware = types.ModuleType("fastapi.middleware.cors")
+_fastapi_middleware.CORSMiddleware = MagicMock  # type: ignore[attr-defined]
+
+_fastapi_static = types.ModuleType("fastapi.staticfiles")
+_fastapi_static.StaticFiles = MagicMock  # type: ignore[attr-defined]
+
+_starlette_ws = types.ModuleType("starlette.websockets")
+_starlette_ws.WebSocketDisconnect = Exception  # type: ignore[attr-defined]
+
+for _key, _mod in [
+    ("fastapi", _fastapi_mod),
+    ("fastapi.middleware.cors", _fastapi_middleware),
+    ("fastapi.staticfiles", _fastapi_static),
+    ("starlette.websockets", _starlette_ws),
+]:
+    sys.modules[_key] = _mod  # type: ignore[assignment]
+
+
+# Import with startup side-effects patched out.
+with (
+    patch("backend.server.ensure_go_server"),
+    patch("backend.server.os.makedirs"),
+):
+    import backend.server as server_module
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_client(tool_response=None):
+    """Return a minimal MCPClient mock."""
+    client = MagicMock()
+    client.call_tool.return_value = tool_response
+    return client
+
+
+# ---------------------------------------------------------------------------
+# run_report — league_id / entry_id / gw input validation
+# ---------------------------------------------------------------------------
+
+class TestRunReportInputValidation:
+    """Verify that non-integer API inputs are rejected gracefully (no 500 crash)."""
+
+    def _call(self, payload):
+        with (
+            patch("backend.server._mcp", return_value=_make_mock_client()),
+            patch("backend.server.LLMClient"),
+        ):
+            return server_module.run_report(payload)
+
+    def test_missing_league_id_returns_error(self):
+        resp = self._call({"type": "league_summary"})
+        assert isinstance(resp, dict), f"Expected dict, got {type(resp)}"
+        assert "error" in resp
+        assert resp["error"] == "league_id is required"
+
+    def test_nonnumeric_league_id_returns_error_not_500(self):
+        """int('abc') must not bubble up as ValueError; must return JSON error dict."""
+        resp = self._call({"type": "league_summary", "league_id": "abc"})
+        assert isinstance(resp, dict), f"Expected dict, got {type(resp)}"
+        assert "error" in resp
+        assert "integer" in resp["error"].lower()
+
+    def test_nonnumeric_entry_id_returns_error_not_500(self):
+        resp = self._call({"type": "waivers", "league_id": "999", "entry_id": "not-a-number"})
+        assert isinstance(resp, dict), f"Expected dict, got {type(resp)}"
+        assert "error" in resp
+        assert "integer" in resp["error"].lower()
+
+    def test_valid_integer_strings_accepted(self):
+        """String '123' should be accepted and converted to int without error."""
+        with (
+            patch("backend.server._mcp", return_value=_make_mock_client({"gameweek": 25})),
+            patch("backend.server.LLMClient"),
+            patch("backend.server.generate_league_summary", return_value={"md": "", "json": {}}),
+            patch("backend.server.save_report", return_value={"md": "/tmp/r.md", "json": "/tmp/r.json"}),
+        ):
+            resp = server_module.run_report({"type": "league_summary", "league_id": "999", "gw": "10"})
+        assert isinstance(resp, dict), f"Expected dict, got {type(resp)}"
+        assert "error" not in resp
+        assert resp.get("ok") is True
+
+    def test_nonnumeric_gw_falls_back_to_zero_not_crash(self):
+        """A non-numeric gw string should fall back to gw=0 (auto-detect), not crash."""
+        with (
+            patch("backend.server._mcp", return_value=_make_mock_client({"gameweek": 25})),
+            patch("backend.server.LLMClient"),
+            patch("backend.server.generate_league_summary", return_value={"md": "", "json": {}}),
+            patch("backend.server.save_report", return_value={"md": "/tmp/r.md", "json": "/tmp/r.json"}),
+        ):
+            resp = server_module.run_report(
+                {"type": "league_summary", "league_id": "999", "gw": "current"}
+            )
+        assert isinstance(resp, dict), f"Expected dict, got {type(resp)}"
+        # Must not contain an "integer" error — gw falls back silently to 0.
+        assert "integer" not in resp.get("error", "")
+
+    def test_unknown_report_type_returns_error(self):
+        resp = self._call({"type": "unknown_type", "league_id": "999"})
+        assert isinstance(resp, dict), f"Expected dict, got {type(resp)}"
+        assert "error" in resp
+        assert "unknown" in resp["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# _parse_chat_payload
+# ---------------------------------------------------------------------------
+
+class TestParseChatPayload:
+    def test_valid_json_with_message_key(self):
+        result = server_module._parse_chat_payload('{"message": "hello", "session_id": "abc"}')
+        assert result["message"] == "hello"
+        assert result["session_id"] == "abc"
+
+    def test_invalid_json_falls_back_to_raw(self):
+        result = server_module._parse_chat_payload("not json at all")
+        assert result == {"message": "not json at all"}
+
+    def test_valid_json_without_message_key_falls_back_to_raw(self):
+        result = server_module._parse_chat_payload('{"foo": "bar"}')
+        assert result == {"message": '{"foo": "bar"}'}
+
+    def test_empty_string_falls_back(self):
+        result = server_module._parse_chat_payload("")
+        assert result == {"message": ""}

--- a/apps/mcp-server/fpl-server/manager_season.go
+++ b/apps/mcp-server/fpl-server/manager_season.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -107,7 +108,9 @@ func buildManagerSeason(cfg ServerConfig, args ManagerSeasonArgs) (ManagerSeason
 	record := SeasonRecord{}
 	totalPts := 0
 	highestGW, highestPts := 0, -1
-	lowestGW, lowestPts := 0, 1<<30
+	// math.MaxInt32 is a reliable sentinel for "not yet set"; 1<<30 would silently
+	// break if a manager ever scored more than ~1 billion points.
+	lowestGW, lowestPts := 0, math.MaxInt32
 	finishedCount := 0
 
 	for _, m := range details.Matches {
@@ -176,7 +179,7 @@ func buildManagerSeason(cfg ServerConfig, args ManagerSeasonArgs) (ManagerSeason
 	if highestPts == -1 {
 		highestPts = 0
 	}
-	if lowestPts == 1<<30 {
+	if lowestPts == math.MaxInt32 {
 		lowestPts = 0
 	}
 

--- a/apps/mcp-server/internal/summary/summary.go
+++ b/apps/mcp-server/internal/summary/summary.go
@@ -542,7 +542,12 @@ func buildPlayerForm(meta map[int]PlayerMeta, ledgerOut model.DraftLedger, trans
 		}
 		risk := 1 - minutesPct
 		own := ownership[id]
-		ownPct := float64(own) / float64(len(entryIDs))
+		// Guard against empty league (len==0) which would produce NaN/+Inf that
+		// json.Marshal cannot serialise, causing a runtime error.
+		var ownPct float64
+		if len(entryIDs) > 0 {
+			ownPct = float64(own) / float64(len(entryIDs))
+		}
 		players = append(players, PlayerForm{
 			Element:      id,
 			Name:         m.Name,

--- a/apps/mcp-server/internal/summary/summary_test.go
+++ b/apps/mcp-server/internal/summary/summary_test.go
@@ -1,0 +1,152 @@
+package summary
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aatrey56/FPL-Draft-Agent/apps/mcp-server/internal/model"
+	"github.com/aatrey56/FPL-Draft-Agent/apps/mcp-server/internal/reconcile"
+	"github.com/aatrey56/FPL-Draft-Agent/apps/mcp-server/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// writeLiveJSON writes a minimal gw/<gw>/live.json with the given element stats.
+func writeLiveJSON(t *testing.T, rawRoot string, gw int, elements map[string]any) {
+	t.Helper()
+	dir := filepath.Join(rawRoot, "gw", itoa(gw))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	payload := map[string]any{"elements": elements}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "live.json"), b, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// itoa converts int to its decimal string representation.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	b := make([]byte, 0, 10)
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// buildPlayerForm — NaN/+Inf guard when entryIDs is empty
+// ---------------------------------------------------------------------------
+
+// TestBuildPlayerForm_EmptyEntryIDs ensures that an empty entryIDs slice does
+// not produce NaN or +Inf ownership percentages that would cause
+// json.MarshalIndent to return an error.
+func TestBuildPlayerForm_EmptyEntryIDs(t *testing.T) {
+	rawRoot := t.TempDir()
+	writeLiveJSON(t, rawRoot, 1, map[string]any{
+		"100": map[string]any{"stats": map[string]any{"minutes": 90, "total_points": 10}},
+		"200": map[string]any{"stats": map[string]any{"minutes": 45, "total_points": 5}},
+	})
+
+	st := store.NewJSONStore(rawRoot)
+	meta := map[int]PlayerMeta{
+		100: {ID: 100, Name: "Player A", PositionType: 3, TeamShort: "ARS"},
+		200: {ID: 200, Name: "Player B", PositionType: 4, TeamShort: "CHE"},
+	}
+
+	// Empty entryIDs is the critical edge case: without the guard,
+	// float64(n) / float64(0) produces +Inf which json.Marshal rejects.
+	summary, err := buildPlayerForm(
+		meta,
+		model.DraftLedger{},
+		[]reconcile.Transaction{},
+		[]reconcile.Trade{},
+		[]int{}, // empty — triggers division by zero without the guard
+		1,       // gw
+		1,       // horizon
+		st,
+	)
+	if err != nil {
+		t.Fatalf("buildPlayerForm returned error: %v", err)
+	}
+
+	for _, p := range summary.Players {
+		if math.IsNaN(p.OwnershipPct) {
+			t.Errorf("player %d: OwnershipPct is NaN, expected 0.0", p.Element)
+		}
+		if math.IsInf(p.OwnershipPct, 0) {
+			t.Errorf("player %d: OwnershipPct is +/-Inf, expected 0.0", p.Element)
+		}
+		if p.OwnershipPct != 0.0 {
+			t.Errorf("player %d: OwnershipPct = %f, want 0.0 for empty league", p.Element, p.OwnershipPct)
+		}
+	}
+
+	// Also verify the result is JSON-serialisable (MarshalIndent fails on NaN/Inf).
+	if _, err := json.MarshalIndent(summary, "", "  "); err != nil {
+		t.Errorf("json.MarshalIndent failed: %v (NaN/Inf likely present)", err)
+	}
+}
+
+// TestBuildPlayerForm_NormalLeague verifies ownership percentages are calculated
+// correctly when entryIDs is non-empty (regression guard).
+func TestBuildPlayerForm_NormalLeague(t *testing.T) {
+	rawRoot := t.TempDir()
+	writeLiveJSON(t, rawRoot, 5, map[string]any{
+		"10": map[string]any{"stats": map[string]any{"minutes": 90, "total_points": 12}},
+		"20": map[string]any{"stats": map[string]any{"minutes": 90, "total_points": 8}},
+	})
+
+	st := store.NewJSONStore(rawRoot)
+	meta := map[int]PlayerMeta{
+		10: {ID: 10, Name: "Salah", PositionType: 3, TeamShort: "LIV"},
+		20: {ID: 20, Name: "Haaland", PositionType: 4, TeamShort: "MCI"},
+	}
+
+	summary, err := buildPlayerForm(
+		meta,
+		model.DraftLedger{},
+		[]reconcile.Transaction{},
+		[]reconcile.Trade{},
+		[]int{101, 102, 103, 104}, // 4 entries, nobody owns anyone
+		5,
+		1,
+		st,
+	)
+	if err != nil {
+		t.Fatalf("buildPlayerForm returned error: %v", err)
+	}
+
+	for _, p := range summary.Players {
+		if math.IsNaN(p.OwnershipPct) || math.IsInf(p.OwnershipPct, 0) {
+			t.Errorf("player %d: OwnershipPct is %f, expected finite value", p.Element, p.OwnershipPct)
+		}
+		// No one owns either player, so ownership must be 0.
+		if p.OwnershipPct != 0.0 {
+			t.Errorf("player %d: OwnershipPct = %f, want 0.0 (unowned)", p.Element, p.OwnershipPct)
+		}
+	}
+
+	if _, err := json.MarshalIndent(summary, "", "  "); err != nil {
+		t.Errorf("json.MarshalIndent failed: %v", err)
+	}
+}


### PR DESCRIPTION
## What changed

| File | Change |
|---|---|
| `internal/summary/summary.go` | Guard `len(entryIDs)==0` in `buildPlayerForm` — prevents NaN/+Inf `OwnershipPct` that causes `json.MarshalIndent` to fail at runtime |
| `fpl-server/manager_season.go` | Replace `1<<30` sentinel with `math.MaxInt32` (add `\"math\"` import) |
| `backend/server.py:run_report` | Wrap `int(league_id_raw)` / `int(entry_id_raw)` / `int(gw)` in `try/except (ValueError, TypeError)` — previously a non-numeric string produced a 500 Internal Server Error |
| `backend/server.py:websocket_endpoint` | Replace deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()` |
| `internal/summary/summary_test.go` | New: 2 tests — `TestBuildPlayerForm_EmptyEntryIDs` (NaN guard), `TestBuildPlayerForm_NormalLeague` (regression) |
| `tests/test_server.py` | New: 10 tests — `run_report` input validation and `_parse_chat_payload` fallback |

## Why

- **NaN/Inf (critical)**: `float64(n) / float64(len(entryIDs))` with an empty league produced `+Inf`, which `encoding/json` cannot serialise → `json.MarshalIndent` returns an error, crashing the entire summary generation pipeline.
- **Safe int parsing (high)**: Sending `{"league_id": "abc"}` to `/api/reports/run` previously raised an unhandled `ValueError` and returned HTTP 500. With the fix it returns `{"error": "league_id and entry_id must be integers"}`.
- **asyncio.get_event_loop() (medium)**: Deprecated since Python 3.10, emits `DeprecationWarning` on 3.12, and can raise an error in future versions. `get_running_loop()` is the correct call inside an already-running async function.
- **1<<30 sentinel (low)**: Magic constant; `math.MaxInt32` is self-documenting and correct on all architectures.

## How to test

```bash
# Go
cd apps/mcp-server
go test ./... -v           # all pass including new summary tests
go vet ./...               # clean

# Python
cd apps/backend
pytest -v                  # 66 pass (56 original + 10 new)
ruff check .               # clean
```

## Commands run
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass (9 packages)
- `pytest` — 66 passed
- `ruff check .` — All checks passed

## Risks / Edge cases
- The NaN guard changes `OwnershipPct` from `+Inf` to `0.0` for an empty league. This is the only semantically valid value (no entries → 0% ownership for everyone).
- The `int()` fallback for `gw` silently treats non-numeric GW strings as `0` (auto-detect mode), which is the least surprising fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)