### PR TITLE
fix: consistency stats count, session ID validation, transaction player meta

### DIFF
--- a/apps/backend/backend/mcp_client.py
+++ b/apps/backend/backend/mcp_client.py
@@ -50,6 +50,11 @@ class MCPClient:
         resp = self._session.post(self.base_url, headers=self._headers(), data=json.dumps(payload))
         resp.raise_for_status()
         self.session_id = resp.headers.get("Mcp-Session-Id")
+        if not self.session_id:
+            raise RuntimeError(
+                "MCP server did not return Mcp-Session-Id header in initialize response; "
+                "cannot proceed without a valid session."
+            )
         # notify initialized
         notif = {"jsonrpc": "2.0", "method": "notifications/initialized"}
         self._session.post(self.base_url, headers=self._headers(), data=json.dumps(notif))

--- a/apps/backend/tests/test_mcp_client.py
+++ b/apps/backend/tests/test_mcp_client.py
@@ -1,0 +1,84 @@
+"""Tests for backend.mcp_client — session ID validation."""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Stub heavy optional dependencies before any backend module is imported.
+# ---------------------------------------------------------------------------
+for _mod in ("openai", "apscheduler", "apscheduler.schedulers.background",
+             "apscheduler.triggers.cron"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+# Stub requests.Session so MCPClient can be imported without a real HTTP library.
+# Other test files may have already stubbed the module without a Session attribute;
+# add it if missing regardless of whether the module was just created or pre-exists.
+if "requests" not in sys.modules:
+    _requests_mod = types.ModuleType("requests")
+    sys.modules["requests"] = _requests_mod
+if not hasattr(sys.modules["requests"], "Session"):
+    sys.modules["requests"].Session = MagicMock  # type: ignore[attr-defined]
+
+_apscheduler_bg = sys.modules["apscheduler.schedulers.background"]
+if not hasattr(_apscheduler_bg, "BackgroundScheduler"):
+    _apscheduler_bg.BackgroundScheduler = MagicMock  # type: ignore[attr-defined]
+
+_apscheduler_cron = sys.modules["apscheduler.triggers.cron"]
+if not hasattr(_apscheduler_cron, "CronTrigger"):
+    _apscheduler_cron.CronTrigger = MagicMock  # type: ignore[attr-defined]
+
+sys.modules["openai"].OpenAI = MagicMock  # type: ignore[attr-defined]
+
+if "zoneinfo" not in sys.modules:
+    _zi = types.ModuleType("zoneinfo")
+    _zi.ZoneInfo = MagicMock  # type: ignore[attr-defined]
+    sys.modules["zoneinfo"] = _zi
+
+import pytest  # noqa: E402
+from backend.mcp_client import MCPClient  # noqa: E402
+
+
+def _mock_session(session_id_header: str | None, status_code: int = 200):
+    """Return a requests.Session mock whose POST returns the given session ID header."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status.return_value = None
+    resp.headers = {}
+    if session_id_header is not None:
+        resp.headers["Mcp-Session-Id"] = session_id_header
+
+    session = MagicMock()
+    session.post.return_value = resp
+    return session
+
+
+class TestEnsureSession:
+    """Verify MCPClient.ensure_session() validates the returned session ID."""
+
+    def test_valid_session_id_stored(self):
+        """When the server returns a valid session ID it should be stored."""
+        client = MCPClient("http://localhost:8080/mcp", "")
+        client._session = _mock_session("sess-abc-123")
+        client.ensure_session()
+        assert client.session_id == "sess-abc-123"
+
+    def test_missing_session_id_raises_runtime_error(self):
+        """If the server omits the Mcp-Session-Id header, a RuntimeError must be raised
+        rather than silently setting session_id to None and continuing.
+        Before the fix, ensure_session() would store None and subsequent calls
+        would send malformed headers."""
+        client = MCPClient("http://localhost:8080/mcp", "")
+        client._session = _mock_session(None)  # header absent
+        with pytest.raises(RuntimeError, match="Mcp-Session-Id"):
+            client.ensure_session()
+
+    def test_already_has_session_skips_init(self):
+        """If session_id is already set, ensure_session() must be a no-op."""
+        client = MCPClient("http://localhost:8080/mcp", "")
+        client.session_id = "existing"
+        mock_session = MagicMock()
+        client._session = mock_session
+        client.ensure_session()
+        mock_session.post.assert_not_called()

--- a/apps/mcp-server/fpl-server/transaction_analysis.go
+++ b/apps/mcp-server/fpl-server/transaction_analysis.go
@@ -148,36 +148,43 @@ func buildTransactionAnalysis(cfg ServerConfig, args TransactionAnalysisArgs) (T
 
 		// Added player.
 		if tx.ElementIn != 0 {
-			meta := playerByID[tx.ElementIn]
-			pos := posLabel[meta.PositionType]
-			addedCount[tx.ElementIn]++
-			if pb, ok := posBreakdown[pos]; ok {
-				pb.Added++
+			// Guard: skip transactions that reference an element not present in the
+			// bootstrap (e.g. mid-season transfers, late additions). A zero-value
+			// struct would produce blank Name/Team and PositionType 0, silently
+			// corrupting the output.
+			if meta, ok := playerByID[tx.ElementIn]; ok {
+				pos := posLabel[meta.PositionType]
+				addedCount[tx.ElementIn]++
+				if pb, ok := posBreakdown[pos]; ok {
+					pb.Added++
+				}
+				managerTx[tx.Entry].Added = append(managerTx[tx.Entry].Added, TxPlayerDetail{
+					Element:      tx.ElementIn,
+					PlayerName:   meta.Name,
+					Team:         teamShort[meta.TeamID],
+					PositionType: meta.PositionType,
+					Kind:         tx.Kind,
+				})
 			}
-			managerTx[tx.Entry].Added = append(managerTx[tx.Entry].Added, TxPlayerDetail{
-				Element:      tx.ElementIn,
-				PlayerName:   meta.Name,
-				Team:         teamShort[meta.TeamID],
-				PositionType: meta.PositionType,
-				Kind:         tx.Kind,
-			})
 		}
 
 		// Dropped player.
 		if tx.ElementOut != 0 {
-			meta := playerByID[tx.ElementOut]
-			pos := posLabel[meta.PositionType]
-			droppedCount[tx.ElementOut]++
-			if pb, ok := posBreakdown[pos]; ok {
-				pb.Dropped++
+			// Same guard as for ElementIn above.
+			if meta, ok := playerByID[tx.ElementOut]; ok {
+				pos := posLabel[meta.PositionType]
+				droppedCount[tx.ElementOut]++
+				if pb, ok := posBreakdown[pos]; ok {
+					pb.Dropped++
+				}
+				managerTx[tx.Entry].Dropped = append(managerTx[tx.Entry].Dropped, TxPlayerDetail{
+					Element:      tx.ElementOut,
+					PlayerName:   meta.Name,
+					Team:         teamShort[meta.TeamID],
+					PositionType: meta.PositionType,
+					Kind:         tx.Kind,
+				})
 			}
-			managerTx[tx.Entry].Dropped = append(managerTx[tx.Entry].Dropped, TxPlayerDetail{
-				Element:      tx.ElementOut,
-				PlayerName:   meta.Name,
-				Team:         teamShort[meta.TeamID],
-				PositionType: meta.PositionType,
-				Kind:         tx.Kind,
-			})
 		}
 	}
 

--- a/apps/mcp-server/fpl-server/waiver_recommendations.go
+++ b/apps/mcp-server/fpl-server/waiver_recommendations.go
@@ -886,14 +886,17 @@ func computeConsistencyStats(rawRoot string, elements []elementInfo, asOfGW int,
 			continue
 		}
 		for _, e := range elements {
-			points := 0.0
+			// Only count gameweeks where the player actually has recorded stats.
+			// If a player is absent from the live data (e.g. injured, not tracked
+			// in an early GW), counting that GW as 0 would artificially deflate
+			// their average and distort standard deviation.
 			if s, ok := live[e.ID]; ok {
-				points = float64(s.TotalPoints)
+				points := float64(s.TotalPoints)
+				cur := stats[e.ID]
+				cur.sum += points
+				cur.sumSq += points * points
+				cur.count++
 			}
-			cur := stats[e.ID]
-			cur.sum += points
-			cur.sumSq += points * points
-			cur.count++
 		}
 	}
 

--- a/apps/mcp-server/fpl-server/waiver_recommendations_test.go
+++ b/apps/mcp-server/fpl-server/waiver_recommendations_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -84,6 +88,114 @@ func TestBuildFixtureIndex_EmptyFixtures(t *testing.T) {
 	idx := buildFixtureIndex([]fixture{}, map[int]string{})
 	if len(idx) != 0 {
 		t.Errorf("empty fixtures should produce empty index, got %d entries", len(idx))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// computeConsistencyStats — only count GWs where the player has live data
+// ---------------------------------------------------------------------------
+
+// writeLiveJSON writes a minimal gw/<gw>/live.json into rawRoot.
+func writeLiveJSON(t *testing.T, rawRoot string, gw int, elements map[string]any) {
+	t.Helper()
+	dir := filepath.Join(rawRoot, "gw", itoa(gw))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir gw dir: %v", err)
+	}
+	payload := map[string]any{"elements": elements}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal live json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "live.json"), b, 0o644); err != nil {
+		t.Fatalf("write live json: %v", err)
+	}
+}
+
+func makeStats(pts int) map[string]any {
+	return map[string]any{"stats": map[string]any{"total_points": pts, "minutes": 90}}
+}
+
+// TestComputeConsistencyStats_PlayerAbsentFromGW verifies that gameweeks where
+// a player has no entry in the live stats file are excluded from the average
+// and standard deviation, rather than being counted as 0-point appearances.
+//
+// Regression test for the bug where cur.count was incremented unconditionally,
+// even when the player was absent from live[e.ID], artificially deflating the
+// player's mean and distorting their standard deviation.
+func TestComputeConsistencyStats_PlayerAbsentFromGW(t *testing.T) {
+	rawRoot := t.TempDir()
+
+	// GW1: player 100 scores 10pts; player 200 absent (e.g. injured / newly added).
+	writeLiveJSON(t, rawRoot, 1, map[string]any{
+		"100": makeStats(10),
+	})
+	// GW2: player 100 scores 8pts; player 200 scores 6pts.
+	writeLiveJSON(t, rawRoot, 2, map[string]any{
+		"100": makeStats(8),
+		"200": makeStats(6),
+	})
+	// GW3: player 100 scores 12pts; player 200 scores 9pts.
+	writeLiveJSON(t, rawRoot, 3, map[string]any{
+		"100": makeStats(12),
+		"200": makeStats(9),
+	})
+
+	elements := []elementInfo{
+		{ID: 100},
+		{ID: 200},
+	}
+
+	avg, stddev, err := computeConsistencyStats(rawRoot, elements, 3, 3)
+	if err != nil {
+		t.Fatalf("computeConsistencyStats: %v", err)
+	}
+
+	// Player 100: present in all 3 GWs → avg = (10+8+12)/3 = 10.0
+	const wantAvg100 = 10.0
+	if math.Abs(avg[100]-wantAvg100) > 1e-9 {
+		t.Errorf("player 100 avg: want %.4f, got %.4f", wantAvg100, avg[100])
+	}
+
+	// Player 200: absent GW1, present GW2+GW3 → avg = (6+9)/2 = 7.5
+	// Before the fix, avg would have been (0+6+9)/3 = 5.0.
+	const wantAvg200 = 7.5
+	if math.Abs(avg[200]-wantAvg200) > 1e-9 {
+		t.Errorf("player 200 avg: want %.4f, got %.4f (was the GW1 absence counted as 0?)", wantAvg200, avg[200])
+	}
+
+	// Player 200 stddev: population stddev of [6, 9] = sqrt(((6-7.5)² + (9-7.5)²)/2) = 1.5
+	const wantStddev200 = 1.5
+	if math.Abs(stddev[200]-wantStddev200) > 1e-9 {
+		t.Errorf("player 200 stddev: want %.4f, got %.4f", wantStddev200, stddev[200])
+	}
+}
+
+// TestComputeConsistencyStats_AllPresent verifies the happy path: when all
+// players appear in every GW, the stats are calculated correctly.
+func TestComputeConsistencyStats_AllPresent(t *testing.T) {
+	rawRoot := t.TempDir()
+
+	writeLiveJSON(t, rawRoot, 5, map[string]any{
+		"10": makeStats(6),
+		"20": makeStats(12),
+	})
+	writeLiveJSON(t, rawRoot, 6, map[string]any{
+		"10": makeStats(10),
+		"20": makeStats(4),
+	})
+
+	elements := []elementInfo{{ID: 10}, {ID: 20}}
+	avg, _, err := computeConsistencyStats(rawRoot, elements, 6, 2)
+	if err != nil {
+		t.Fatalf("computeConsistencyStats: %v", err)
+	}
+
+	if math.Abs(avg[10]-8.0) > 1e-9 {
+		t.Errorf("player 10 avg: want 8.0, got %f", avg[10])
+	}
+	if math.Abs(avg[20]-8.0) > 1e-9 {
+		t.Errorf("player 20 avg: want 8.0, got %f", avg[20])
 	}
 }
 


### PR DESCRIPTION
## What changed

### 1. `computeConsistencyStats` — waiver_recommendations.go
`cur.count++` was called even when a player was absent from the GW's live stats map (injured, new player, data gap). Absent GWs were silently treated as 0-point appearances, artificially deflating averages and distorting standard deviations used in waiver consistency scoring.

Fix: moved all accumulation (`sum`, `sumSq`, `count++`) inside the `if s, ok := live[e.ID]; ok` block so only gameweeks with actual recorded stats count.

### 2. `ensure_session()` — mcp_client.py
`self.session_id = resp.headers.get("Mcp-Session-Id")` could store `None` if the Go server didn't return the header (e.g. misconfiguration, transport error). All subsequent `call_tool` calls would silently pass a `None` session ID.

Fix: raise `RuntimeError` immediately after the initialize call if the header is absent.

### 3. `transaction_analysis.go` — player metadata guard
`meta := playerByID[tx.ElementIn]` returned a zero-value struct for element IDs not in the bootstrap (mid-season player additions, data freshness gaps). This produced transaction entries with blank `Name`/`Team` and `PositionType 0`, silently corrupting the output.

Fix: use `meta, ok := playerByID[id]` and skip the transaction leg when `ok` is false.

## Why
- Bug 1 corrupts core analytics (waiver ranking). A player absent for one GW was penalised as if they scored 0 every time they didn't appear in the live file.
- Bug 2 causes silent session failures — hard to debug in production.
- Bug 3 produces invisible data corruption in the transactions output.

## How to test
```bash
cd apps/mcp-server && go test ./...
cd apps/backend && python3 -m pytest tests/test_mcp_client.py -v
```

## Commands run
```
go fmt ./... && go vet ./... && go test ./...   # all packages pass
python3 -m pytest                               # 77 passed
ruff check .                                    # clean
```

## Risks / Edge cases
- The consistency stats change means players with very few GW appearances now get higher averages. This is the correct domain behaviour (e.g. a player returning from injury after 2 GWs).
- The `ensure_session` guard will surface a previously-silent failure as an exception. Callers already expected `call_tool` to raise on error, so this is safe.
- The transaction metadata guard silently drops malformed legs (unknown element). A future improvement could log a warning, but no noise is better than corrupt output.