### PR TITLE
fix(go): guard against unknown element in current_roster picks loop

### DIFF
--- a/apps/mcp-server/fpl-server/current_roster.go
+++ b/apps/mcp-server/fpl-server/current_roster.go
@@ -125,7 +125,14 @@ func buildCurrentRoster(cfg ServerConfig, args CurrentRosterArgs) (CurrentRoster
 	starters := make([]RosterPlayerInfo, 0, 11)
 	bench := make([]RosterPlayerInfo, 0, 4)
 	for _, p := range snap.Picks {
-		meta := playerByID[p.Element]
+		// Guard: skip picks referencing an element absent from the bootstrap
+		// (e.g. data freshness gap, mid-season player addition).  A zero-value
+		// struct would produce blank Name/Team and PositionType 0, silently
+		// corrupting the roster output.
+		meta, ok := playerByID[p.Element]
+		if !ok {
+			continue
+		}
 		info := RosterPlayerInfo{
 			Element:      p.Element,
 			Name:         meta.Name,


### PR DESCRIPTION
## What changed
Added an `ok` check for the `playerByID[p.Element]` map access in `current_roster.go` (line 128). When the element ID was absent from the bootstrap map, Go returned a zero-value struct, producing roster entries with blank `Name`, blank `Team`, and `PositionType 0`.

## Why
Same class of silent data corruption as fixed in `transaction_analysis.go` (PR #66 / fix #3). The pattern `meta := map[key]` without existence check is a Go footgun when the zero-value is semantically invalid.

Picks that reference an unknown element are now silently skipped (consistent with the transaction analysis approach), leaving the rest of the roster intact.

## How to test
```bash
cd apps/mcp-server && go test ./...
```

## Commands run
```
go fmt ./... && go vet ./... && go test ./...   # all packages pass
python3 -m pytest                               # 77 passed
```

## Risks / Edge cases
- In normal operation, every roster pick maps to a known element, so the `continue` path is never hit.
- Skipping rather than erroring is intentional: a partial roster is more useful than no roster when one pick has a stale element reference.