### PR TITLE
fix(ci): add conftest.py to set dummy LEAGUE_ID/ENTRY_ID for pytest

### DIFF
--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -1,0 +1,23 @@
+"""
+pytest configuration — set required environment variables before any backend
+module is imported.
+
+config.py instantiates ``SETTINGS = Settings()`` at module level (line 100).
+``Settings`` calls ``_require_int_env("LEAGUE_ID")`` and
+``_require_int_env("ENTRY_ID")`` via field ``default_factory``, so importing
+*any* backend module in CI (where no ``.env`` file exists) raises::
+
+    ValueError: LEAGUE_ID environment variable is required but not set.
+
+pytest loads ``conftest.py`` before collecting or importing test modules, so
+setting the variables here guarantees they are present when the first
+``import backend.*`` occurs.
+
+``os.environ.setdefault`` is used so that any real values already present in
+the environment (e.g. from a developer's ``.env`` or a CI secret) are
+preserved and never overwritten.
+"""
+import os
+
+os.environ.setdefault("LEAGUE_ID", "99999")
+os.environ.setdefault("ENTRY_ID", "88888")


### PR DESCRIPTION
## What changed
Added `apps/backend/tests/conftest.py` with two `os.environ.setdefault` calls for `LEAGUE_ID` and `ENTRY_ID`.

## Why
`config.py` runs `SETTINGS = Settings()` at module level. `Settings` calls `_require_int_env("LEAGUE_ID")` and `_require_int_env("ENTRY_ID")` immediately on import, so importing any backend module in CI (no `.env`, no secrets set) crashed every test file at collection time:

```
ValueError: LEAGUE_ID environment variable is required but not set.
```

This caused all 5 test files to fail in CI on both Python 3.11 and 3.12, blocking PR #61 from merging.

pytest loads `conftest.py` before collecting or importing test modules, so the dummy values are present before the first `import backend.*`. `os.environ.setdefault` is used so that any real value already in the environment (developer's `.env`, CI secret) is never overwritten.

## How to test
```bash
# Simulate CI: no inherited env vars
cd apps/backend
env -i HOME="$HOME" PATH="$PATH" PYTHONPATH="$(pwd)" python3 -m pytest tests/ -v
# → 77 passed
```

## Commands run
```
env -i ... python3 -m pytest tests/   → 77 passed
ruff check .                          → clean
```

## Risks / Edge cases
- `setdefault` means real `LEAGUE_ID`/`ENTRY_ID` values (from `.env` or CI secrets) are never touched.
- Dummy values `99999` / `88888` are never used in actual API calls — all test files mock the MCP client and HTTP layer.