### PR TITLE
fix: resolve 6 correctness bugs and refresh GW26/27 live data

### DIFF
--- a/apps/backend/backend/agent.py
+++ b/apps/backend/backend/agent.py
@@ -105,7 +105,7 @@ class Agent:
             "who dropped", ("position", "targeted"), ("position", "popular"),
             "popular adds", "popular drops",
         ],
-        "head_to_head": ["head to head", " h2h ", "record against"],
+        "head_to_head": ["head to head", "h2h", "record against"],
         "manager_season": [
             "season stats", "season history", "season record",
             "how have i done", "overall record", "weekly scores",
@@ -131,7 +131,7 @@ class Agent:
         "standings": ["standings", "table"],
         "league_summary": ["league summary", ("summary", "league")],
         "transactions": ["transactions", "trades", ("waivers", "summary")],
-        "lineup": ["lineup efficiency", "bench points", "bench"],
+        "lineup": ["lineup efficiency", "bench points"],
         "strength": ["strength of schedule", "schedule difficulty"],
         "ownership": ["ownership", "scarcity"],
         "matchup_summary": [

--- a/apps/mcp-server/fpl-server/fixture_difficulty.go
+++ b/apps/mcp-server/fpl-server/fixture_difficulty.go
@@ -175,8 +175,8 @@ func buildFixtureDifficulty(cfg ServerConfig, args FixtureDifficultyArgs) (Fixtu
 	}
 
 	seasonWeight, recentWeight := horizonWeights(h)
-	concededSeason := computePointsConcededByPosition(cfg.RawRoot, elements, fixturesByGW, asOfGW, asOfGW)
-	concededRecent := computePointsConcededByPosition(cfg.RawRoot, elements, fixturesByGW, asOfGW, h)
+	concededSeason := computePointsConcededByPosition(cfg.RawRoot, elements, asOfGW, asOfGW)
+	concededRecent := computePointsConcededByPosition(cfg.RawRoot, elements, asOfGW, h)
 
 	fixtureList := fixturesByGW[nextGW]
 	contexts := buildFixtureContexts(fixtureList, teamShort)

--- a/apps/mcp-server/fpl-server/head_to_head.go
+++ b/apps/mcp-server/fpl-server/head_to_head.go
@@ -125,6 +125,9 @@ func buildHeadToHead(cfg ServerConfig, args HeadToHeadArgs) (HeadToHeadOutput, e
 
 		resultA := resultFromScore(scoreA, scoreB)
 
+		if !m.Finished {
+			continue
+		}
 		h2h := H2HMatch{
 			Gameweek: m.Event,
 			ScoreA:   scoreA,
@@ -134,18 +137,16 @@ func buildHeadToHead(cfg ServerConfig, args HeadToHeadArgs) (HeadToHeadOutput, e
 		}
 		matches = append(matches, h2h)
 
-		if m.Finished {
-			switch resultA {
-			case "W":
-				recordA.Wins++
-				recordB.Losses++
-			case "L":
-				recordA.Losses++
-				recordB.Wins++
-			case "D":
-				recordA.Draws++
-				recordB.Draws++
-			}
+		switch resultA {
+		case "W":
+			recordA.Wins++
+			recordB.Losses++
+		case "L":
+			recordA.Losses++
+			recordB.Wins++
+		case "D":
+			recordA.Draws++
+			recordB.Draws++
 		}
 	}
 

--- a/apps/mcp-server/fpl-server/manager_season.go
+++ b/apps/mcp-server/fpl-server/manager_season.go
@@ -134,6 +134,9 @@ func buildManagerSeason(cfg ServerConfig, args ManagerSeasonArgs) (ManagerSeason
 		oppName := nameByEntry[oppEntryID]
 		result := resultFromScore(score, oppScore)
 
+		if !m.Finished {
+			continue
+		}
 		gw := SeasonGameweek{
 			Gameweek:      m.Event,
 			Score:         score,
@@ -145,25 +148,23 @@ func buildManagerSeason(cfg ServerConfig, args ManagerSeasonArgs) (ManagerSeason
 		}
 		gameweeks = append(gameweeks, gw)
 
-		if m.Finished {
-			totalPts += score
-			finishedCount++
-			switch result {
-			case "W":
-				record.Wins++
-			case "D":
-				record.Draws++
-			case "L":
-				record.Losses++
-			}
-			if score > highestPts {
-				highestPts = score
-				highestGW = m.Event
-			}
-			if score < lowestPts {
-				lowestPts = score
-				lowestGW = m.Event
-			}
+		totalPts += score
+		finishedCount++
+		switch result {
+		case "W":
+			record.Wins++
+		case "D":
+			record.Draws++
+		case "L":
+			record.Losses++
+		}
+		if score > highestPts {
+			highestPts = score
+			highestGW = m.Event
+		}
+		if score < lowestPts {
+			lowestPts = score
+			lowestGW = m.Event
 		}
 	}
 

--- a/apps/mcp-server/fpl-server/new_tools_test.go
+++ b/apps/mcp-server/fpl-server/new_tools_test.go
@@ -416,8 +416,10 @@ func TestBuildHeadToHead(t *testing.T) {
 		if out.TeamA.Wins != 0 || out.TeamA.Draws != 0 || out.TeamA.Losses != 0 {
 			t.Errorf("unfinished match should not count in record: A=%+v", out.TeamA)
 		}
-		if len(out.Matches) != 1 {
-			t.Errorf("match should still appear in list: len=%d", len(out.Matches))
+		// Unfinished matches are filtered from the output list; only
+		// completed matches appear so callers only see real results.
+		if len(out.Matches) != 0 {
+			t.Errorf("unfinished match should not appear in list: len=%d", len(out.Matches))
 		}
 	})
 }
@@ -531,6 +533,28 @@ func TestBuildManagerSeason(t *testing.T) {
 			t.Fatal("expected error when neither entry_id nor entry_name supplied")
 		}
 	})
+
+	// Regression: unfinished future matches must not appear in the Gameweeks list
+	// (previously all 38 GWs including unplayed ones were returned with score=0, result=D).
+	t.Run("UnfinishedMatchesExcludedFromGameweeksList", func(t *testing.T) {
+		dir, cfg := tmpCfg(t)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
+			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 60, "league_entry_2": 2, "league_entry_2_points": 50},
+			map[string]any{"event": 2, "finished": false, "league_entry_1": 1, "league_entry_1_points": 0, "league_entry_2": 2, "league_entry_2_points": 0},
+		})
+		entryID := 200
+		out, err := buildManagerSeason(cfg, ManagerSeasonArgs{LeagueID: 100, EntryID: &entryID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Only GW1 (finished) should appear; GW2 (unfinished/future) must be excluded.
+		if len(out.Gameweeks) != 1 {
+			t.Errorf("expected 1 finished gameweek in list, got %d", len(out.Gameweeks))
+		}
+		if len(out.Gameweeks) > 0 && out.Gameweeks[0].Gameweek != 1 {
+			t.Errorf("expected GW1 in list, got GW%d", out.Gameweeks[0].Gameweek)
+		}
+	})
 }
 
 // ---- TestParseFloat ----
@@ -560,7 +584,8 @@ func TestParseFloat(t *testing.T) {
 
 func TestBuildPlayerGWStats(t *testing.T) {
 	// liveEntry builds the per-element live stats object.
-	liveEntry := func(pts int, xg, xa string) map[string]any {
+	// expected_goals and expected_assists are float64, matching the FPL API response.
+	liveEntry := func(pts int, xg, xa float64) map[string]any {
 		return map[string]any{
 			"stats": map[string]any{
 				"minutes": 90, "total_points": pts,
@@ -576,7 +601,7 @@ func TestBuildPlayerGWStats(t *testing.T) {
 		writeGameJSON(t, dir, 3)
 		for gw := 1; gw <= 3; gw++ {
 			writeJSON(t, filepath.Join(dir, fmt.Sprintf("gw/%d/live.json", gw)), map[string]any{
-				"elements": map[string]any{"1": liveEntry(gw*4, "0.5", "0.3")},
+				"elements": map[string]any{"1": liveEntry(gw*4, 0.5, 0.3)},
 			})
 		}
 		name := "Salah"
@@ -606,7 +631,7 @@ func TestBuildPlayerGWStats(t *testing.T) {
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 1)
 		writeJSON(t, filepath.Join(dir, "gw/1/live.json"), map[string]any{
-			"elements": map[string]any{"3": liveEntry(6, "0.1", "0.6")},
+			"elements": map[string]any{"3": liveEntry(6, 0.1, 0.6)},
 		})
 		name := "Arnold"
 		out, err := buildPlayerGWStats(cfg, PlayerGWStatsArgs{PlayerName: &name})
@@ -624,7 +649,7 @@ func TestBuildPlayerGWStats(t *testing.T) {
 		writeBootstrap(t, dir)
 		for gw := 1; gw <= 5; gw++ {
 			writeJSON(t, filepath.Join(dir, fmt.Sprintf("gw/%d/live.json", gw)), map[string]any{
-				"elements": map[string]any{"1": liveEntry(gw*3, "0.0", "0.0")},
+				"elements": map[string]any{"1": liveEntry(gw*3, 0.0, 0.0)},
 			})
 		}
 		startGW, endGW := 2, 3
@@ -645,12 +670,12 @@ func TestBuildPlayerGWStats(t *testing.T) {
 		}
 	})
 
-	t.Run("XGParsedFromString", func(t *testing.T) {
+	t.Run("XGAndXAAsFloat64", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 1)
 		writeJSON(t, filepath.Join(dir, "gw/1/live.json"), map[string]any{
-			"elements": map[string]any{"1": liveEntry(10, "0.75", "0.50")},
+			"elements": map[string]any{"1": liveEntry(10, 0.75, 0.50)},
 		})
 		id := 1
 		gw := 1

--- a/apps/mcp-server/fpl-server/player_gw_stats.go
+++ b/apps/mcp-server/fpl-server/player_gw_stats.go
@@ -126,14 +126,14 @@ func buildPlayerGWStats(cfg ServerConfig, args PlayerGWStatsArgs) (PlayerGWStats
 		var liveResp struct {
 			Elements map[string]struct {
 				Stats struct {
-					Minutes     int    `json:"minutes"`
-					TotalPoints int    `json:"total_points"`
-					GoalsScored int    `json:"goals_scored"`
-					Assists     int    `json:"assists"`
-					CleanSheets int    `json:"clean_sheets"`
-					BPS         int    `json:"bps"`
-					XG          string `json:"expected_goals"`
-					XA          string `json:"expected_assists"`
+					Minutes     int     `json:"minutes"`
+					TotalPoints int     `json:"total_points"`
+					GoalsScored int     `json:"goals_scored"`
+					Assists     int     `json:"assists"`
+					CleanSheets int     `json:"clean_sheets"`
+					BPS         int     `json:"bps"`
+					XG          float64 `json:"expected_goals"`
+					XA          float64 `json:"expected_assists"`
 				} `json:"stats"`
 			} `json:"elements"`
 		}
@@ -148,8 +148,8 @@ func buildPlayerGWStats(cfg ServerConfig, args PlayerGWStatsArgs) (PlayerGWStats
 		}
 
 		s := data.Stats
-		xg := parseFloat(s.XG)
-		xa := parseFloat(s.XA)
+		xg := s.XG
+		xa := s.XA
 
 		entry := PlayerGWEntry{
 			Gameweek:    gw,

--- a/apps/mcp-server/internal/summary/summary.go
+++ b/apps/mcp-server/internal/summary/summary.go
@@ -196,14 +196,23 @@ type TransactionsSummary struct {
 	Entries        []EntryTransactions `json:"entries"`
 }
 
+// NegativeBenchContributor identifies a bench player whose deduction makes
+// bench_points negative, so callers can surface the responsible player.
+type NegativeBenchContributor struct {
+	Element int    `json:"element"`
+	Name    string `json:"name"`
+	Points  int    `json:"points"`
+}
+
 type LineupEfficiencyEntry struct {
-	EntryID                int    `json:"entry_id"`
-	EntryName              string `json:"entry_name"`
-	BenchPoints            int    `json:"bench_points"`
-	BenchPointsPlayed      int    `json:"bench_points_played"`
-	ZeroMinuteStarters     []int  `json:"zero_minute_starters"`
-	ZeroMinuteStarterCount int    `json:"zero_minute_starter_count"`
-	MissingSnapshot        bool   `json:"missing_snapshot"`
+	EntryID                   int                        `json:"entry_id"`
+	EntryName                 string                     `json:"entry_name"`
+	BenchPoints               int                        `json:"bench_points"`
+	BenchPointsPlayed         int                        `json:"bench_points_played"`
+	ZeroMinuteStarters        []int                      `json:"zero_minute_starters"`
+	ZeroMinuteStarterCount    int                        `json:"zero_minute_starter_count"`
+	NegativeBenchContributors []NegativeBenchContributor `json:"negative_bench_contributors,omitempty"`
+	MissingSnapshot           bool                       `json:"missing_snapshot"`
 }
 
 type LineupEfficiencySummary struct {
@@ -444,7 +453,7 @@ func BuildLeagueSummaries(st *store.JSONStore, derivedRoot string, leagueID int,
 			return err
 		}
 
-		lineup := buildLineupEfficiency(leagueID, gw, entryIDs, entryNameByID, snapshotsByEntry, liveByElement)
+		lineup := buildLineupEfficiency(leagueID, gw, entryIDs, entryNameByID, snapshotsByEntry, liveByElement, meta)
 		outLineup := filepath.Join(derivedRoot, fmt.Sprintf("summary/lineup_efficiency/%d/gw/%d.json", leagueID, gw))
 		if err := writeJSON(outLineup, lineup); err != nil {
 			return err
@@ -1033,7 +1042,7 @@ func BuildTransactionsSummary(st *store.JSONStore, derivedRoot string, leagueID 
 	return writeJSON(outTx, txSummary)
 }
 
-func buildLineupEfficiency(leagueID int, gw int, entryIDs []int, entryNameByID map[int]string, snapshots map[int]*ledger.EntrySnapshot, liveByElement map[int]points.LiveStats) LineupEfficiencySummary {
+func buildLineupEfficiency(leagueID int, gw int, entryIDs []int, entryNameByID map[int]string, snapshots map[int]*ledger.EntrySnapshot, liveByElement map[int]points.LiveStats, meta map[int]PlayerMeta) LineupEfficiencySummary {
 	out := LineupEfficiencySummary{
 		LeagueID:       leagueID,
 		Gameweek:       gw,
@@ -1053,6 +1062,7 @@ func buildLineupEfficiency(leagueID int, gw int, entryIDs []int, entryNameByID m
 		benchPoints := 0
 		benchPointsPlayed := 0
 		zeroMinuteStarters := make([]int, 0)
+		negContribs := make([]NegativeBenchContributor, 0)
 
 		for _, p := range snap.Picks {
 			stats := liveByElement[p.Element]
@@ -1065,17 +1075,28 @@ func buildLineupEfficiency(leagueID int, gw int, entryIDs []int, entryNameByID m
 				if stats.Minutes > 0 {
 					benchPointsPlayed += stats.TotalPoints
 				}
+				if stats.TotalPoints < 0 {
+					negContribs = append(negContribs, NegativeBenchContributor{
+						Element: p.Element,
+						Name:    meta[p.Element].Name,
+						Points:  stats.TotalPoints,
+					})
+				}
 			}
 		}
 
-		out.Entries = append(out.Entries, LineupEfficiencyEntry{
+		entry := LineupEfficiencyEntry{
 			EntryID:                entryID,
 			EntryName:              entryNameByID[entryID],
 			BenchPoints:            benchPoints,
 			BenchPointsPlayed:      benchPointsPlayed,
 			ZeroMinuteStarters:     zeroMinuteStarters,
 			ZeroMinuteStarterCount: len(zeroMinuteStarters),
-		})
+		}
+		if len(negContribs) > 0 {
+			entry.NegativeBenchContributors = negContribs
+		}
+		out.Entries = append(out.Entries, entry)
 	}
 	return out
 }

--- a/apps/mcp-server/internal/summary/summary_test.go
+++ b/apps/mcp-server/internal/summary/summary_test.go
@@ -204,8 +204,7 @@ func TestBuildLineupEfficiency_NegativeBenchContributor(t *testing.T) {
 	}
 	entry := out.Entries[0]
 
-	// bench_points = -2 + 2 + 2 + 2 = 4 starters points excluded; bench = -2+2+2+2=4? No.
-	// bench is positions 12-15: player 99 (-2), player 12 (2), player 13 (2), player 14 (2) = 4 total.
+	// Positions 12-15 are bench: player 99 (-2) + player 12 (2) + player 13 (2) + player 14 (2) = 4.
 	if entry.BenchPoints != 4 {
 		t.Errorf("bench_points=%d want 4 (99:-2 + 12:2 + 13:2 + 14:2)", entry.BenchPoints)
 	}


### PR DESCRIPTION
## What changed

- **Bug #1 (CRITICAL):** `player_gw_stats` XG/XA fields changed from `string` to `float64`. FPL API returns these as numbers; the string declaration caused json.Unmarshal to fail silently on every GW, returning `total_points=0` and empty `gameweeks` for all players.
- **Bug #2 (HIGH):** `computePointsConcededByPosition` now reads fixtures from `gw/N/live.json` instead of bootstrap-static.json. Bootstrap only has upcoming GW fixtures; historical GW1-25 fixture pairings were always empty, making all FDR/fixture scores 0.
- **Bug #3 (MEDIUM):** `manager_season` and `head_to_head` now skip unfinished matches. Previously all 38 GWs including unplayed future fixtures appeared with score=0, result=D.
- **Bug #4 (MEDIUM):** `LineupEfficiencyEntry` gains a `negative_bench_contributors` field listing any bench player with TotalPoints < 0 (name + element + points), so callers can explain why bench_points is negative.
- **Bug #5 (LOW):** Added `"h2h"` (no space padding) to head_to_head intent keywords in agent.py. `" h2h "` never matched e.g. `"h2h glock vs..."`.
- **Bug #6 (LOW):** Removed standalone `"bench"` from lineup intent keywords. It was too broad and fired on current_roster queries like "who's on my bench".
- **Data:** Fetched GW26/GW27 live data; `game.json` updated to `current_event=27`. Regenerated all GW1-27 derived summaries.

## Why

These bugs made several key tools either completely broken (player_gw_stats, FDR) or misleading (manager_season, h2h with fake future results). The intent routing bugs caused incorrect tool dispatch.

## How to test

```bash
# Go
cd apps/mcp-server
go test ./...
go vet ./...
go fmt ./...

# Python
cd apps/backend
pytest
ruff check .
```

## Commands run

- `go test ./...` — all pass
- `go vet ./...` — clean
- `go fmt ./...` — applied
- `pytest` — 77 passed
- `ruff check .` — clean

## Risks / Edge cases

- **Bug #2:** `loadFixturesFromLive` silently skips a GW if `fixtures` key is absent from live.json (returns `continue`). GWs with missing fixture data contribute 0 to the conceded average, which is the same as the previous behaviour but now correctly attributed.
- **Bug #3:** The `Finished` field is still present in `SeasonGameweek` and `H2HMatch` structs (always true now) for API compatibility.
- **Bug #4:** `negative_bench_contributors` is `omitempty` — absent from output when bench points are non-negative (no change for the common case).
- Derived summary files for GW1-25 were regenerated with the corrected fixture scoring code; old cached files are replaced.