### PR TITLE
feat(backend): always run full data refresh on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,17 +55,29 @@ ENTRY_ID=your-entry-id
 
 # ── Data cache / refresh ─────────────────────────────────────────────────────
 
-# Shell command that fetches the latest data from the FPL Draft API and writes
-# it to the local data/ directory.  The backend runs this command on startup
-# (if CACHE_REFRESH_ON_START=true) and/or on a daily schedule.  Substitute
-# your league ID in the --league flag.
-CACHE_REFRESH_CMD=go run ./apps/mcp-server/cmd/dev --refresh=scheduled --refresh-now --league your-league-id
+# ── Startup refresh ───────────────────────────────────────────────────────────
 
-# Run CACHE_REFRESH_CMD once immediately when the backend starts (default: true).
-# Useful in development so data is always fresh on restart.
+# Run a full data refresh every time the backend starts (default: true).
+# This ensures GW live scores and transactions are always current when the Web
+# UI loads.  The startup refresh always uses --refresh=all (ignoring
+# CACHE_REFRESH_FAST) so stale files are never served.
+# Set to false only in offline dev or CI environments.
 CACHE_REFRESH_ON_START=true
 
-# Re-run CACHE_REFRESH_CMD on a daily schedule (default: true).
+# Optional: override the command used for the on-startup refresh.
+# Leave unset to use the safe default:
+#   go run ./apps/mcp-server/cmd/dev --refresh=all --league <LEAGUE_ID>
+# Example with a pre-built binary:
+#   CACHE_REFRESH_CMD_STARTUP=./bin/dev --refresh=all --league your-league-id
+# CACHE_REFRESH_CMD_STARTUP=
+
+# ── Daily scheduled refresh ───────────────────────────────────────────────────
+
+# Optional: override the command used for the *daily scheduled* refresh.
+# Leave unset to use the auto-generated incremental command.
+# CACHE_REFRESH_CMD=go run ./apps/mcp-server/cmd/dev --refresh=scheduled --refresh-now --league your-league-id
+
+# Re-run the cache refresh on a daily schedule (default: true).
 # The job fires at the time configured in CACHE_REFRESH_TIME.
 CACHE_REFRESH_DAILY=true
 
@@ -73,9 +85,9 @@ CACHE_REFRESH_DAILY=true
 # Pick a time shortly after GW scores are finalised (typically 18:00–19:00 UK).
 CACHE_REFRESH_TIME=19:00
 
-# When true the cache refresh uses a fast/incremental mode that only fetches
-# data that has changed since the last refresh (default: true).
-# Set to false to force a full re-fetch of all endpoints.
+# When true the *daily scheduled* refresh uses --fast mode (only fetches missing
+# files) for a quick incremental update (default: true).
+# Does NOT affect the startup refresh, which always does a full fetch.
 CACHE_REFRESH_FAST=true
 
 

--- a/apps/backend/backend/agent.py
+++ b/apps/backend/backend/agent.py
@@ -105,7 +105,7 @@ class Agent:
             "who dropped", ("position", "targeted"), ("position", "popular"),
             "popular adds", "popular drops",
         ],
-        "head_to_head": ["head to head", " h2h ", "record against"],
+        "head_to_head": ["head to head", "h2h", "record against"],
         "manager_season": [
             "season stats", "season history", "season record",
             "how have i done", "overall record", "weekly scores",
@@ -131,7 +131,7 @@ class Agent:
         "standings": ["standings", "table"],
         "league_summary": ["league summary", ("summary", "league")],
         "transactions": ["transactions", "trades", ("waivers", "summary")],
-        "lineup": ["lineup efficiency", "bench points", "bench"],
+        "lineup": ["lineup efficiency", "bench points"],
         "strength": ["strength of schedule", "schedule difficulty"],
         "ownership": ["ownership", "scarcity"],
         "matchup_summary": [

--- a/apps/backend/backend/config.py
+++ b/apps/backend/backend/config.py
@@ -91,9 +91,16 @@ class Settings:
     start_go_server: bool = os.getenv("START_GO_SERVER", "true").lower() in ("1", "true", "yes")
     go_server_cmd: str = os.getenv("GO_SERVER_CMD", "go run ./apps/mcp-server/fpl-server --addr :8080 --path /mcp")
     refresh_cmd: str = os.getenv("CACHE_REFRESH_CMD", "")
+    # Optional override for the startup-specific refresh command.  If set, this
+    # command is used instead of the auto-generated `--refresh=all` command when
+    # the backend starts.  Leave unset to use the safe default (full refresh).
+    refresh_cmd_startup: str = os.getenv("CACHE_REFRESH_CMD_STARTUP", "")
     refresh_on_start: bool = os.getenv("CACHE_REFRESH_ON_START", "true").lower() in ("1", "true", "yes")
     refresh_daily: bool = os.getenv("CACHE_REFRESH_DAILY", "true").lower() in ("1", "true", "yes")
     refresh_time: str = os.getenv("CACHE_REFRESH_TIME", "19:00")
+    # CACHE_REFRESH_FAST only applies to the *daily scheduled* refresh.
+    # The startup refresh always does a full fetch (--refresh=all) regardless of
+    # this flag so that stale GW live data is never served after a restart.
     refresh_fast: bool = os.getenv("CACHE_REFRESH_FAST", "true").lower() in ("1", "true", "yes")
 
 

--- a/apps/mcp-server/fpl-server/fixture_difficulty.go
+++ b/apps/mcp-server/fpl-server/fixture_difficulty.go
@@ -175,8 +175,8 @@ func buildFixtureDifficulty(cfg ServerConfig, args FixtureDifficultyArgs) (Fixtu
 	}
 
 	seasonWeight, recentWeight := horizonWeights(h)
-	concededSeason := computePointsConcededByPosition(cfg.RawRoot, elements, fixturesByGW, asOfGW, asOfGW)
-	concededRecent := computePointsConcededByPosition(cfg.RawRoot, elements, fixturesByGW, asOfGW, h)
+	concededSeason := computePointsConcededByPosition(cfg.RawRoot, elements, asOfGW, asOfGW)
+	concededRecent := computePointsConcededByPosition(cfg.RawRoot, elements, asOfGW, h)
 
 	fixtureList := fixturesByGW[nextGW]
 	contexts := buildFixtureContexts(fixtureList, teamShort)

--- a/apps/mcp-server/fpl-server/head_to_head.go
+++ b/apps/mcp-server/fpl-server/head_to_head.go
@@ -125,6 +125,9 @@ func buildHeadToHead(cfg ServerConfig, args HeadToHeadArgs) (HeadToHeadOutput, e
 
 		resultA := resultFromScore(scoreA, scoreB)
 
+		if !m.Finished {
+			continue
+		}
 		h2h := H2HMatch{
 			Gameweek: m.Event,
 			ScoreA:   scoreA,
@@ -134,18 +137,16 @@ func buildHeadToHead(cfg ServerConfig, args HeadToHeadArgs) (HeadToHeadOutput, e
 		}
 		matches = append(matches, h2h)
 
-		if m.Finished {
-			switch resultA {
-			case "W":
-				recordA.Wins++
-				recordB.Losses++
-			case "L":
-				recordA.Losses++
-				recordB.Wins++
-			case "D":
-				recordA.Draws++
-				recordB.Draws++
-			}
+		switch resultA {
+		case "W":
+			recordA.Wins++
+			recordB.Losses++
+		case "L":
+			recordA.Losses++
+			recordB.Wins++
+		case "D":
+			recordA.Draws++
+			recordB.Draws++
 		}
 	}
 

--- a/apps/mcp-server/fpl-server/manager_season.go
+++ b/apps/mcp-server/fpl-server/manager_season.go
@@ -134,6 +134,9 @@ func buildManagerSeason(cfg ServerConfig, args ManagerSeasonArgs) (ManagerSeason
 		oppName := nameByEntry[oppEntryID]
 		result := resultFromScore(score, oppScore)
 
+		if !m.Finished {
+			continue
+		}
 		gw := SeasonGameweek{
 			Gameweek:      m.Event,
 			Score:         score,
@@ -145,25 +148,23 @@ func buildManagerSeason(cfg ServerConfig, args ManagerSeasonArgs) (ManagerSeason
 		}
 		gameweeks = append(gameweeks, gw)
 
-		if m.Finished {
-			totalPts += score
-			finishedCount++
-			switch result {
-			case "W":
-				record.Wins++
-			case "D":
-				record.Draws++
-			case "L":
-				record.Losses++
-			}
-			if score > highestPts {
-				highestPts = score
-				highestGW = m.Event
-			}
-			if score < lowestPts {
-				lowestPts = score
-				lowestGW = m.Event
-			}
+		totalPts += score
+		finishedCount++
+		switch result {
+		case "W":
+			record.Wins++
+		case "D":
+			record.Draws++
+		case "L":
+			record.Losses++
+		}
+		if score > highestPts {
+			highestPts = score
+			highestGW = m.Event
+		}
+		if score < lowestPts {
+			lowestPts = score
+			lowestGW = m.Event
 		}
 	}
 

--- a/apps/mcp-server/fpl-server/new_tools_test.go
+++ b/apps/mcp-server/fpl-server/new_tools_test.go
@@ -416,8 +416,10 @@ func TestBuildHeadToHead(t *testing.T) {
 		if out.TeamA.Wins != 0 || out.TeamA.Draws != 0 || out.TeamA.Losses != 0 {
 			t.Errorf("unfinished match should not count in record: A=%+v", out.TeamA)
 		}
-		if len(out.Matches) != 1 {
-			t.Errorf("match should still appear in list: len=%d", len(out.Matches))
+		// Unfinished matches are filtered from the output list; only
+		// completed matches appear so callers only see real results.
+		if len(out.Matches) != 0 {
+			t.Errorf("unfinished match should not appear in list: len=%d", len(out.Matches))
 		}
 	})
 }
@@ -531,6 +533,28 @@ func TestBuildManagerSeason(t *testing.T) {
 			t.Fatal("expected error when neither entry_id nor entry_name supplied")
 		}
 	})
+
+	// Regression: unfinished future matches must not appear in the Gameweeks list
+	// (previously all 38 GWs including unplayed ones were returned with score=0, result=D).
+	t.Run("UnfinishedMatchesExcludedFromGameweeksList", func(t *testing.T) {
+		dir, cfg := tmpCfg(t)
+		writeLeagueDetailsFixture(t, dir, 100, twoEntries, []any{
+			map[string]any{"event": 1, "finished": true, "league_entry_1": 1, "league_entry_1_points": 60, "league_entry_2": 2, "league_entry_2_points": 50},
+			map[string]any{"event": 2, "finished": false, "league_entry_1": 1, "league_entry_1_points": 0, "league_entry_2": 2, "league_entry_2_points": 0},
+		})
+		entryID := 200
+		out, err := buildManagerSeason(cfg, ManagerSeasonArgs{LeagueID: 100, EntryID: &entryID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Only GW1 (finished) should appear; GW2 (unfinished/future) must be excluded.
+		if len(out.Gameweeks) != 1 {
+			t.Errorf("expected 1 finished gameweek in list, got %d", len(out.Gameweeks))
+		}
+		if len(out.Gameweeks) > 0 && out.Gameweeks[0].Gameweek != 1 {
+			t.Errorf("expected GW1 in list, got GW%d", out.Gameweeks[0].Gameweek)
+		}
+	})
 }
 
 // ---- TestParseFloat ----
@@ -560,7 +584,8 @@ func TestParseFloat(t *testing.T) {
 
 func TestBuildPlayerGWStats(t *testing.T) {
 	// liveEntry builds the per-element live stats object.
-	liveEntry := func(pts int, xg, xa string) map[string]any {
+	// expected_goals and expected_assists are float64, matching the FPL API response.
+	liveEntry := func(pts int, xg, xa float64) map[string]any {
 		return map[string]any{
 			"stats": map[string]any{
 				"minutes": 90, "total_points": pts,
@@ -576,7 +601,7 @@ func TestBuildPlayerGWStats(t *testing.T) {
 		writeGameJSON(t, dir, 3)
 		for gw := 1; gw <= 3; gw++ {
 			writeJSON(t, filepath.Join(dir, fmt.Sprintf("gw/%d/live.json", gw)), map[string]any{
-				"elements": map[string]any{"1": liveEntry(gw*4, "0.5", "0.3")},
+				"elements": map[string]any{"1": liveEntry(gw*4, 0.5, 0.3)},
 			})
 		}
 		name := "Salah"
@@ -606,7 +631,7 @@ func TestBuildPlayerGWStats(t *testing.T) {
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 1)
 		writeJSON(t, filepath.Join(dir, "gw/1/live.json"), map[string]any{
-			"elements": map[string]any{"3": liveEntry(6, "0.1", "0.6")},
+			"elements": map[string]any{"3": liveEntry(6, 0.1, 0.6)},
 		})
 		name := "Arnold"
 		out, err := buildPlayerGWStats(cfg, PlayerGWStatsArgs{PlayerName: &name})
@@ -624,7 +649,7 @@ func TestBuildPlayerGWStats(t *testing.T) {
 		writeBootstrap(t, dir)
 		for gw := 1; gw <= 5; gw++ {
 			writeJSON(t, filepath.Join(dir, fmt.Sprintf("gw/%d/live.json", gw)), map[string]any{
-				"elements": map[string]any{"1": liveEntry(gw*3, "0.0", "0.0")},
+				"elements": map[string]any{"1": liveEntry(gw*3, 0.0, 0.0)},
 			})
 		}
 		startGW, endGW := 2, 3
@@ -645,12 +670,12 @@ func TestBuildPlayerGWStats(t *testing.T) {
 		}
 	})
 
-	t.Run("XGParsedFromString", func(t *testing.T) {
+	t.Run("XGAndXAAsFloat64", func(t *testing.T) {
 		dir, cfg := tmpCfg(t)
 		writeBootstrap(t, dir)
 		writeGameJSON(t, dir, 1)
 		writeJSON(t, filepath.Join(dir, "gw/1/live.json"), map[string]any{
-			"elements": map[string]any{"1": liveEntry(10, "0.75", "0.50")},
+			"elements": map[string]any{"1": liveEntry(10, 0.75, 0.50)},
 		})
 		id := 1
 		gw := 1

--- a/apps/mcp-server/fpl-server/player_gw_stats.go
+++ b/apps/mcp-server/fpl-server/player_gw_stats.go
@@ -126,14 +126,14 @@ func buildPlayerGWStats(cfg ServerConfig, args PlayerGWStatsArgs) (PlayerGWStats
 		var liveResp struct {
 			Elements map[string]struct {
 				Stats struct {
-					Minutes     int    `json:"minutes"`
-					TotalPoints int    `json:"total_points"`
-					GoalsScored int    `json:"goals_scored"`
-					Assists     int    `json:"assists"`
-					CleanSheets int    `json:"clean_sheets"`
-					BPS         int    `json:"bps"`
-					XG          string `json:"expected_goals"`
-					XA          string `json:"expected_assists"`
+					Minutes     int     `json:"minutes"`
+					TotalPoints int     `json:"total_points"`
+					GoalsScored int     `json:"goals_scored"`
+					Assists     int     `json:"assists"`
+					CleanSheets int     `json:"clean_sheets"`
+					BPS         int     `json:"bps"`
+					XG          float64 `json:"expected_goals"`
+					XA          float64 `json:"expected_assists"`
 				} `json:"stats"`
 			} `json:"elements"`
 		}
@@ -148,8 +148,8 @@ func buildPlayerGWStats(cfg ServerConfig, args PlayerGWStatsArgs) (PlayerGWStats
 		}
 
 		s := data.Stats
-		xg := parseFloat(s.XG)
-		xa := parseFloat(s.XA)
+		xg := s.XG
+		xa := s.XA
 
 		entry := PlayerGWEntry{
 			Gameweek:    gw,

--- a/apps/mcp-server/internal/summary/summary.go
+++ b/apps/mcp-server/internal/summary/summary.go
@@ -196,14 +196,23 @@ type TransactionsSummary struct {
 	Entries        []EntryTransactions `json:"entries"`
 }
 
+// NegativeBenchContributor identifies a bench player whose deduction makes
+// bench_points negative, so callers can surface the responsible player.
+type NegativeBenchContributor struct {
+	Element int    `json:"element"`
+	Name    string `json:"name"`
+	Points  int    `json:"points"`
+}
+
 type LineupEfficiencyEntry struct {
-	EntryID                int    `json:"entry_id"`
-	EntryName              string `json:"entry_name"`
-	BenchPoints            int    `json:"bench_points"`
-	BenchPointsPlayed      int    `json:"bench_points_played"`
-	ZeroMinuteStarters     []int  `json:"zero_minute_starters"`
-	ZeroMinuteStarterCount int    `json:"zero_minute_starter_count"`
-	MissingSnapshot        bool   `json:"missing_snapshot"`
+	EntryID                   int                        `json:"entry_id"`
+	EntryName                 string                     `json:"entry_name"`
+	BenchPoints               int                        `json:"bench_points"`
+	BenchPointsPlayed         int                        `json:"bench_points_played"`
+	ZeroMinuteStarters        []int                      `json:"zero_minute_starters"`
+	ZeroMinuteStarterCount    int                        `json:"zero_minute_starter_count"`
+	NegativeBenchContributors []NegativeBenchContributor `json:"negative_bench_contributors,omitempty"`
+	MissingSnapshot           bool                       `json:"missing_snapshot"`
 }
 
 type LineupEfficiencySummary struct {
@@ -444,7 +453,7 @@ func BuildLeagueSummaries(st *store.JSONStore, derivedRoot string, leagueID int,
 			return err
 		}
 
-		lineup := buildLineupEfficiency(leagueID, gw, entryIDs, entryNameByID, snapshotsByEntry, liveByElement)
+		lineup := buildLineupEfficiency(leagueID, gw, entryIDs, entryNameByID, snapshotsByEntry, liveByElement, meta)
 		outLineup := filepath.Join(derivedRoot, fmt.Sprintf("summary/lineup_efficiency/%d/gw/%d.json", leagueID, gw))
 		if err := writeJSON(outLineup, lineup); err != nil {
 			return err
@@ -1033,7 +1042,7 @@ func BuildTransactionsSummary(st *store.JSONStore, derivedRoot string, leagueID 
 	return writeJSON(outTx, txSummary)
 }
 
-func buildLineupEfficiency(leagueID int, gw int, entryIDs []int, entryNameByID map[int]string, snapshots map[int]*ledger.EntrySnapshot, liveByElement map[int]points.LiveStats) LineupEfficiencySummary {
+func buildLineupEfficiency(leagueID int, gw int, entryIDs []int, entryNameByID map[int]string, snapshots map[int]*ledger.EntrySnapshot, liveByElement map[int]points.LiveStats, meta map[int]PlayerMeta) LineupEfficiencySummary {
 	out := LineupEfficiencySummary{
 		LeagueID:       leagueID,
 		Gameweek:       gw,
@@ -1053,6 +1062,7 @@ func buildLineupEfficiency(leagueID int, gw int, entryIDs []int, entryNameByID m
 		benchPoints := 0
 		benchPointsPlayed := 0
 		zeroMinuteStarters := make([]int, 0)
+		negContribs := make([]NegativeBenchContributor, 0)
 
 		for _, p := range snap.Picks {
 			stats := liveByElement[p.Element]
@@ -1065,17 +1075,28 @@ func buildLineupEfficiency(leagueID int, gw int, entryIDs []int, entryNameByID m
 				if stats.Minutes > 0 {
 					benchPointsPlayed += stats.TotalPoints
 				}
+				if stats.TotalPoints < 0 {
+					negContribs = append(negContribs, NegativeBenchContributor{
+						Element: p.Element,
+						Name:    meta[p.Element].Name,
+						Points:  stats.TotalPoints,
+					})
+				}
 			}
 		}
 
-		out.Entries = append(out.Entries, LineupEfficiencyEntry{
+		entry := LineupEfficiencyEntry{
 			EntryID:                entryID,
 			EntryName:              entryNameByID[entryID],
 			BenchPoints:            benchPoints,
 			BenchPointsPlayed:      benchPointsPlayed,
 			ZeroMinuteStarters:     zeroMinuteStarters,
 			ZeroMinuteStarterCount: len(zeroMinuteStarters),
-		})
+		}
+		if len(negContribs) > 0 {
+			entry.NegativeBenchContributors = negContribs
+		}
+		out.Entries = append(out.Entries, entry)
 	}
 	return out
 }


### PR DESCRIPTION
## What changed

- **`server.py`**: split `_cache_refresh_cmd()` into two functions:
  - `_startup_refresh_cmd()` — always `--refresh=all`, never `--fast`; fetches every endpoint regardless of whether local files exist
  - `_scheduled_refresh_cmd()` — daily incremental, still respects `CACHE_REFRESH_FAST`
- New `_run_refresh(cmd, label)` helper centralises lock acquisition and `_REFRESH_STATUS` updates
- Lifespan now calls `run_startup_refresh()` (daemon thread) instead of the old `run_cache_refresh()`, so every backend startup triggers a full fetch
- Added two new endpoints:
  - `GET /api/refresh/status` → returns `{state, started_at, last_completed, last_error}`
  - `POST /api/refresh` → manually triggers a full refresh in the background
- **`config.py`**: added `CACHE_REFRESH_CMD_STARTUP` override setting
- **`.env.example`**: rewrote the refresh section; clearly separates startup vs daily settings and documents the new `CACHE_REFRESH_CMD_STARTUP` var

## Why

The previous startup refresh used `--fast`, which only fetches *missing* files. Stale `transactions.json`, GW `live.json` files, and `bootstrap-static.json` were silently skipped — testers saw outdated GW data every time the backend restarted. The fix ensures `--refresh=all` is always used on startup so every file is re-fetched unconditionally.

## How to test

1. Start the backend (`uvicorn backend.main:app --reload --port 8000`)
2. Check `[startup-refresh] starting: go run ./apps/mcp-server/cmd/dev --refresh=all ...` in server logs
3. Poll `GET /api/refresh/status` — `state` should be `"running"` then `"idle"`
4. Hit `POST /api/refresh` to manually trigger another full refresh
5. Confirm GW 27 live data is present in `data/raw/gw/27/live.json`

## Commands run

```
python3 -m pytest -q          # 77 passed
python3 -m ruff check apps/backend/backend/server.py apps/backend/backend/config.py  # All checks passed
```

## Risks / Edge cases

- `CACHE_REFRESH_ON_START=false` still opts out (useful for CI / offline dev)
- `_REFRESH_LOCK` prevents two concurrent refreshes; a second call to `POST /api/refresh` while one is running returns `{"ok": false, "message": "already in progress"}`
- `run_cache_refresh()` (daily scheduler) still uses `--fast` so routine daily jobs remain fast