### PR TITLE
fix(agent): add dedicated renderers for league_entries, ownership, SoS

### DIFF
--- a/apps/backend/backend/agent.py
+++ b/apps/backend/backend/agent.py
@@ -679,6 +679,10 @@ class Agent:
             return self._handle_league_summary(text, tool_events)
         if self._looks_like("win_list", lower):
             return self._handle_wins_list(text, tool_events)
+        # Check "strength" before "schedule" because "strength of schedule"
+        # contains "schedule" and would be misrouted otherwise.
+        if self._looks_like("strength", lower):
+            return self._handle_strength_of_schedule(text, tool_events)
         if self._looks_like("schedule", lower):
             return self._handle_schedule(text, tool_events)
         if self._looks_like("fixtures", lower):
@@ -693,14 +697,12 @@ class Agent:
             return self._handle_transactions(text, tool_events)
         if self._looks_like("lineup", lower):
             return self._handle_lineup_efficiency(text, tool_events)
-        if self._looks_like("strength", lower):
-            return self._handle_simple_tool(text, tool_events, "strength_of_schedule", "Strength of schedule")
         if self._looks_like("ownership", lower):
-            return self._handle_simple_tool(text, tool_events, "ownership_scarcity", "Ownership scarcity")
+            return self._handle_ownership_scarcity(text, tool_events)
         if self._looks_like("matchup_summary", lower):
             return self._handle_matchup_summary(text, tool_events)
         if "league entries" in lower or "all teams" in lower:
-            return self._handle_simple_tool(text, tool_events, "league_entries", "League teams")
+            return self._handle_league_entries(text, tool_events)
 
         league_id = self._extract_league_id(text) or self._default_league_id()
         if self._looks_like_team_name_only(text, league_id, tool_events):
@@ -1656,6 +1658,95 @@ class Agent:
         if result:
             return f"{title} data is ready. Ask for a specific team or detail if you want a summary."
         return f"{title} data is unavailable."
+
+    def _handle_league_entries(self, text: str, tool_events: List[Dict[str, Any]]) -> str:
+        """Render the list of teams in the league (#77)."""
+        league_id = self._extract_league_id(text) or self._default_league_id()
+        result = self._call_tool(tool_events, "league_entries", {"league_id": league_id})
+        if not isinstance(result, dict):
+            return "League entries data is unavailable right now."
+        teams = result.get("teams", [])
+        if not teams:
+            return "No teams found in this league."
+        lines = [f"League teams ({len(teams)}):"]
+        for t in teams:
+            name = t.get("entry_name") or "Unknown"
+            short = t.get("short_name") or ""
+            entry_id = t.get("entry_id", "")
+            if short:
+                lines.append(f"- {name} ({short}) — ID {entry_id}")
+            else:
+                lines.append(f"- {name} — ID {entry_id}")
+        return "\n".join(lines)
+
+    def _handle_ownership_scarcity(self, text: str, tool_events: List[Dict[str, Any]]) -> str:
+        """Render ownership/scarcity breakdown by position (#78)."""
+        league_id = self._extract_league_id(text) or self._default_league_id()
+        gw = self._extract_gw(text)
+        if gw is None:
+            gw = self._default_gw()
+        args: Dict[str, Any] = {"league_id": league_id, "gw": gw if gw is not None else 0}
+        result = self._call_tool(tool_events, "ownership_scarcity", args)
+        if not isinstance(result, dict):
+            return "Ownership scarcity data is unavailable right now."
+
+        gw_label = result.get("gameweek") or gw or "current"
+        lines = [f"Ownership scarcity (GW{gw_label}):"]
+
+        owned = result.get("owned_totals") or {}
+        unowned = result.get("unowned_totals") or {}
+        if owned or unowned:
+            lines.append(f"  Owned: GK {owned.get('gk', 0)}, DEF {owned.get('def', 0)}, "
+                         f"MID {owned.get('mid', 0)}, FWD {owned.get('fwd', 0)} "
+                         f"(total {owned.get('total', 0)})")
+            lines.append(f"  Free agents: GK {unowned.get('gk', 0)}, DEF {unowned.get('def', 0)}, "
+                         f"MID {unowned.get('mid', 0)}, FWD {unowned.get('fwd', 0)} "
+                         f"(total {unowned.get('total', 0)})")
+
+        hoarders = result.get("hoarders") or {}
+        if hoarders:
+            lines.append("Position hoarders:")
+            for pos, entries in hoarders.items():
+                if entries:
+                    names = ", ".join(
+                        f"{h.get('entry_name', '?')} ({h.get('count', 0)})"
+                        for h in entries[:3]
+                    )
+                    lines.append(f"  {pos.upper()}: {names}")
+        return "\n".join(lines)
+
+    def _handle_strength_of_schedule(self, text: str, tool_events: List[Dict[str, Any]]) -> str:
+        """Render strength-of-schedule rankings (#79)."""
+        league_id = self._extract_league_id(text) or self._default_league_id()
+        gw = self._extract_gw(text)
+        if gw is None:
+            gw = self._default_gw()
+        horizon = self._extract_horizon(text) or 5
+        args: Dict[str, Any] = {"league_id": league_id, "horizon": horizon}
+        if gw is not None:
+            args["as_of_gw"] = gw
+        result = self._call_tool(tool_events, "strength_of_schedule", args)
+        if not isinstance(result, dict):
+            return "Strength of schedule data is unavailable right now."
+
+        entries = result.get("entries", [])
+        if not entries:
+            return "No strength of schedule data available."
+
+        gw_label = result.get("gameweek") or gw or "current"
+        lines = [f"Strength of schedule (as of GW{gw_label}, next {horizon} GWs):"]
+        # Sort by easiest future schedule (lowest future_opponent_avg_rank = easier)
+        sorted_entries = sorted(entries, key=lambda e: e.get("future_opponent_avg_rank", 99))
+        for i, e in enumerate(sorted_entries, 1):
+            name = e.get("entry_name") or "Unknown"
+            fut_rank = e.get("future_opponent_avg_rank", 0)
+            fut_top = e.get("future_opponents_top_half", 0)
+            fut_bot = e.get("future_opponents_bottom_half", 0)
+            lines.append(
+                f"{i}. {name} — avg opp rank {fut_rank:.1f} "
+                f"({fut_top} top-half, {fut_bot} bottom-half)"
+            )
+        return "\n".join(lines)
 
     def _load_element_map(self) -> Dict[int, str]:
         if self._element_name_cache is not None:

--- a/apps/backend/tests/test_agent.py
+++ b/apps/backend/tests/test_agent.py
@@ -628,3 +628,114 @@ class TestRoutingBugs:
         call_args = self.mcp.call_tool.call_args
         tool_args = call_args[0][1]  # second positional arg is the args dict
         assert tool_args.get("player_name") == "Saka"
+
+
+# ---------------------------------------------------------------------------
+# Dedicated tool renderers (#77, #78, #79)
+# ---------------------------------------------------------------------------
+
+class TestSimpleToolRenderers:
+    """Verify that league_entries, ownership_scarcity, and
+    strength_of_schedule return formatted output, not generic 'data is ready'."""
+
+    def setup_method(self) -> None:
+        self.mcp = MagicMock()
+        self.mcp.list_tools.return_value = []
+        self.llm = MagicMock()
+        self.llm.available.return_value = False
+        with patch("backend.agent.get_rag_index", return_value=MagicMock(search=lambda *a, **k: [])):
+            self.agent = Agent(self.mcp, self.llm)
+        self.agent._session["league_id"] = 14204
+        self.agent._session["entry_id"] = 286192
+
+    def test_league_entries_renders_team_list(self) -> None:
+        self.mcp.call_tool.return_value = {
+            "league_id": 14204,
+            "teams": [
+                {"entry_id": 100, "entry_name": "Boot Gang", "short_name": "BG"},
+                {"entry_id": 200, "entry_name": "Glock Tua", "short_name": "GT"},
+            ],
+        }
+        result = self.agent._try_route("show all teams", [])
+        assert result is not None
+        assert "Boot Gang" in result
+        assert "Glock Tua" in result
+        assert "data is ready" not in result
+
+    def test_ownership_scarcity_renders_breakdown(self) -> None:
+        self.mcp.call_tool.return_value = {
+            "league_id": 14204,
+            "gameweek": 27,
+            "owned_totals": {"gk": 10, "def": 40, "mid": 40, "fwd": 20, "total": 110},
+            "unowned_totals": {"gk": 5, "def": 10, "mid": 15, "fwd": 5, "total": 35},
+            "hoarders": {"mid": [{"entry_name": "Boot Gang", "count": 8}]},
+        }
+        result = self.agent._try_route("player ownership %", [])
+        assert result is not None
+        assert "Owned" in result
+        assert "Free agents" in result
+        assert "data is ready" not in result
+
+    def test_strength_of_schedule_renders_rankings(self) -> None:
+        self.mcp.call_tool.return_value = {
+            "league_id": 14204,
+            "gameweek": 27,
+            "entries": [
+                {
+                    "entry_name": "Boot Gang",
+                    "future_opponent_avg_rank": 3.2,
+                    "future_opponents_top_half": 2,
+                    "future_opponents_bottom_half": 3,
+                },
+                {
+                    "entry_name": "Glock Tua",
+                    "future_opponent_avg_rank": 5.8,
+                    "future_opponents_top_half": 4,
+                    "future_opponents_bottom_half": 1,
+                },
+            ],
+        }
+        result = self.agent._try_route("strength of schedule next 5 gws", [])
+        assert result is not None
+        assert "Boot Gang" in result
+        assert "avg opp rank" in result
+        assert "data is ready" not in result
+        # Verify sort order: Boot Gang (3.2) should appear before Glock Tua (5.8)
+        assert result.index("Boot Gang") < result.index("Glock Tua")
+
+    # ---- edge cases ----
+
+    def test_league_entries_empty_teams(self) -> None:
+        """Empty teams list should return a user-friendly message."""
+        self.mcp.call_tool.return_value = {"teams": []}
+        result = self.agent._try_route("show all teams", [])
+        assert result is not None
+        assert "no teams" in result.lower() or "No teams" in result
+
+    def test_league_entries_non_dict_return(self) -> None:
+        """Non-dict MCP return should show unavailable message."""
+        self.mcp.call_tool.return_value = "error: connection refused"
+        result = self.agent._try_route("show all teams", [])
+        assert result is not None
+        assert "unavailable" in result.lower()
+
+    def test_ownership_scarcity_non_dict_return(self) -> None:
+        """Non-dict MCP return should show unavailable message."""
+        self.mcp.call_tool.return_value = "error: connection refused"
+        result = self.agent._try_route("player ownership %", [])
+        assert result is not None
+        assert "unavailable" in result.lower()
+
+    def test_strength_of_schedule_empty_entries(self) -> None:
+        """Empty entries should return a user-friendly message."""
+        self.mcp.call_tool.return_value = {"entries": []}
+        result = self.agent._try_route("strength of schedule next 5 gws", [])
+        assert result is not None
+        assert "no strength" in result.lower() or "No strength" in result
+
+    def test_strength_of_schedule_non_dict_return(self) -> None:
+        """Non-dict MCP return should show unavailable message."""
+        self.mcp.call_tool.return_value = "error: connection refused"
+        result = self.agent._try_route("strength of schedule next 5 gws", [])
+        assert result is not None
+        assert "unavailable" in result.lower()

--- a/apps/backend/tests/test_agent.py
+++ b/apps/backend/tests/test_agent.py
@@ -703,6 +703,48 @@ class TestSimpleToolRenderers:
         # Verify sort order: Boot Gang (3.2) should appear before Glock Tua (5.8)
         assert result.index("Boot Gang") < result.index("Glock Tua")
 
+    def test_strength_of_schedule_routes_to_correct_tool(self) -> None:
+        """'strength of schedule' must route to strength_of_schedule, not schedule handler."""
+        self.mcp.call_tool.return_value = {
+            "league_id": 14204,
+            "gameweek": 27,
+            "entries": [
+                {
+                    "entry_name": "Boot Gang",
+                    "future_opponent_avg_rank": 3.2,
+                    "future_opponents_top_half": 2,
+                    "future_opponents_bottom_half": 3,
+                },
+            ],
+        }
+        self.agent._try_route("strength of schedule next 5 gws", [])
+        tool_name = self.mcp.call_tool.call_args[0][0]
+        assert tool_name == "strength_of_schedule", (
+            f"Expected 'strength_of_schedule' but routed to '{tool_name}'. "
+            "Check that the 'strength' intent is tested before 'schedule' in _try_route()."
+        )
+
+    def test_schedule_difficulty_routes_to_strength_tool(self) -> None:
+        """'schedule difficulty' must route to strength_of_schedule, not schedule handler."""
+        self.mcp.call_tool.return_value = {
+            "league_id": 14204,
+            "gameweek": 27,
+            "entries": [
+                {
+                    "entry_name": "Glock Tua",
+                    "future_opponent_avg_rank": 5.8,
+                    "future_opponents_top_half": 4,
+                    "future_opponents_bottom_half": 1,
+                },
+            ],
+        }
+        self.agent._try_route("schedule difficulty", [])
+        tool_name = self.mcp.call_tool.call_args[0][0]
+        assert tool_name == "strength_of_schedule", (
+            f"Expected 'strength_of_schedule' but routed to '{tool_name}'. "
+            "'schedule difficulty' starts with 'schedule' — the strength check must come first."
+        )
+
     # ---- edge cases ----
 
     def test_league_entries_empty_teams(self) -> None:


### PR DESCRIPTION
## What changed
Replaced generic "data is ready" responses with formatted output for three MCP tools:
- **league_entries**: now renders a numbered team list with names and IDs
- **ownership_scarcity**: now renders owned/unowned totals by position + hoarders
- **strength_of_schedule**: now renders ranked SoS table sorted by easiest future schedule

Also moved the "strength" intent check before "schedule" in routing to prevent "strength of schedule" from being misrouted to the schedule handler.

Closes #77, #78, #79

## How to test
```bash
cd apps/backend && python3 -m pytest tests/test_agent.py::TestSimpleToolRenderers -v
```

## Commands run
- `python3 -m pytest tests/ -v` — 83 passed
- `ruff check backend/ tests/` — All checks passed

## Risks / Edge cases
- The renderers handle empty data gracefully (returns "unavailable" or "no data")
- SoS sorting handles missing `future_opponent_avg_rank` by defaulting to 99