### PR TITLE
fix(backend): resolve 5 routing bugs (#76, #80, #85, #86, #87)

### DIFF
--- a/apps/backend/backend/agent.py
+++ b/apps/backend/backend/agent.py
@@ -124,6 +124,7 @@ class Agent:
             ("win", "week"), ("win", "gw"), ("win", "gameweek"),
             ("won", "week"), ("won", "gw"), ("won", "gameweek"),
             ("wins", "week"), ("wins", "gw"), ("wins", "gameweek"),
+            ("wins", "each"),
         ],
         "schedule": ["schedule", ("who does", "play")],
         "fixtures": ["fixtures", "fixture list"],
@@ -458,12 +459,21 @@ class Agent:
             return 0
 
     def _default_entry_id(self) -> Optional[int]:
+        """Return the session entry_id, falling back to SETTINGS.entry_id."""
         entry_id = self._session.get("entry_id")
         if entry_id:
             try:
                 return int(entry_id)
             except Exception:
-                return None
+                pass
+        # Fall back to the config-level default so "my team" works even when
+        # the session hasn't been seeded by an explicit entry_id yet.
+        try:
+            cfg_id = int(SETTINGS.entry_id)
+            if cfg_id:
+                return cfg_id
+        except Exception:
+            pass
         return None
 
     def _default_entry_name(self) -> Optional[str]:
@@ -663,6 +673,10 @@ class Agent:
             return self._handle_waiver(text, tool_events)
         if self._looks_like("streak", lower):
             return self._handle_streak(text, tool_events)
+        # "who won GW27" asks about the league winner, not personal win history.
+        # Route to league_summary when "who" + "won" + a GW reference appear together.
+        if "who" in lower and "won" in lower and GW_PATTERN.search(lower):
+            return self._handle_league_summary(text, tool_events)
         if self._looks_like("win_list", lower):
             return self._handle_wins_list(text, tool_events)
         if self._looks_like("schedule", lower):
@@ -977,6 +991,12 @@ class Agent:
                 # Can't set pending for draft since it's not in pending handler — fall through to LLM.
                 return None
 
+        # Extract optional round filter (e.g. "round 1", "rd 3").
+        round_filter: Optional[int] = None
+        round_match = re.search(r"(?:round|rd)\s*(\d+)", text, re.IGNORECASE)
+        if round_match:
+            round_filter = int(round_match.group(1))
+
         args: Dict[str, Any] = {"league_id": league_id}
         if entry_id:
             args["entry_id"] = entry_id
@@ -985,8 +1005,13 @@ class Agent:
             return "Draft history is unavailable right now."
 
         picks = result.get("picks", [])
+        # Client-side round filter (Go tool doesn't support it natively).
+        if round_filter is not None:
+            picks = [p for p in picks if p.get("round") == round_filter]
+
         filtered_by = result.get("filtered_by") or ""
-        header = f"Draft picks for **{filtered_by}**:" if filtered_by else "Draft picks (all teams):"
+        round_label = f" (round {round_filter})" if round_filter else ""
+        header = f"Draft picks for **{filtered_by}**{round_label}:" if filtered_by else f"Draft picks (all teams){round_label}:"
         lines = [header]
         for p in picks[:30]:
             manager = p.get("entry_name") or "Unknown"
@@ -997,6 +1022,8 @@ class Agent:
             lines.append(f"  Rd{p.get('round')}, Pick{p.get('pick')}: {manager} → {player} ({team}, {pos}){auto}")
         if len(picks) > 30:
             lines.append(f"  ... and {len(picks) - 30} more picks.")
+        if round_filter is not None and not picks:
+            lines.append(f"  No picks found for round {round_filter}.")
         return "\n".join(lines)
 
     def _handle_manager_season(
@@ -1110,6 +1137,9 @@ class Agent:
                        "each gameweek", "per gw", "stats for", "points for", "how many points has",
                        "how has", "done each", "scored each"):
             player_text = re.sub(phrase, "", player_text, flags=re.IGNORECASE).strip()
+
+        # Strip a leading "for" left over after phrase removal (e.g. "gameweek points for Saka").
+        player_text = re.sub(r"^for\s+", "", player_text, flags=re.IGNORECASE).strip()
 
         # Extract potential player name (2-3 word chunk that's not a keyword).
         words = player_text.split()

--- a/apps/backend/tests/test_agent.py
+++ b/apps/backend/tests/test_agent.py
@@ -504,3 +504,127 @@ class TestGwSessionStickiness:
         assert len(calls) >= 2
         second_call_args = calls[-1][0][1]
         assert second_call_args.get("gw") != 3, "GW from first query leaked to second query"
+
+
+# ---------------------------------------------------------------------------
+# PR6: Routing bugs — entry_id fallback, draft round, who won, player name
+# ---------------------------------------------------------------------------
+
+class TestRoutingBugs:
+    """Tests for bug fixes #76, #80, #85, #86, #87."""
+
+    def setup_method(self) -> None:
+        self.mcp = MagicMock()
+        self.mcp.list_tools.return_value = []
+        self.llm = MagicMock()
+        self.llm.available.return_value = False
+        with patch("backend.agent.get_rag_index", return_value=MagicMock(search=lambda *a, **k: [])):
+            self.agent = Agent(self.mcp, self.llm)
+
+    # ---- #76: _default_entry_id falls back to SETTINGS.entry_id ----
+
+    def test_default_entry_id_falls_back_to_settings(self) -> None:
+        """When session has no entry_id, _default_entry_id returns SETTINGS.entry_id."""
+        self.agent._session["entry_id"] = None
+        with patch("backend.agent.SETTINGS") as mock_settings:
+            mock_settings.entry_id = 42
+            result = self.agent._default_entry_id()
+        assert result == 42
+
+    def test_default_entry_id_session_takes_priority(self) -> None:
+        """Session entry_id should take priority over SETTINGS."""
+        self.agent._session["entry_id"] = 100
+        result = self.agent._default_entry_id()
+        assert result == 100
+
+    def test_current_roster_uses_settings_fallback(self) -> None:
+        """'my team' should work even without session entry_id (#76)."""
+        self.agent._session["league_id"] = 14204
+        self.agent._session["entry_id"] = None
+        self.mcp.call_tool.return_value = {
+            "entry_name": "My Team", "gameweek": 5,
+            "starters": [], "bench": [],
+        }
+        with patch("backend.agent.SETTINGS") as mock_settings:
+            mock_settings.entry_id = 99
+            mock_settings.league_id = 14204
+            result = self.agent._try_route("show my team", [])
+        assert result is not None
+        assert "unavailable" not in result.lower()
+
+    # ---- #80: draft_picks round filter ----
+
+    def test_draft_picks_filters_by_round(self) -> None:
+        """'who did we draft in round 1' should only show round 1 picks (#80)."""
+        self.agent._session["league_id"] = 14204
+        self.agent._session["entry_id"] = 100
+        self.mcp.call_tool.return_value = {
+            "filtered_by": "My Team",
+            "picks": [
+                {"round": 1, "pick": 3, "entry_name": "Me", "player_name": "Salah", "team": "LIV", "position_type": 3},
+                {"round": 2, "pick": 14, "entry_name": "Me", "player_name": "Rice", "team": "ARS", "position_type": 3},
+                {"round": 3, "pick": 19, "entry_name": "Me", "player_name": "Saka", "team": "ARS", "position_type": 3},
+            ],
+        }
+        result = self.agent._try_route("who did we draft in round 1", [])
+        assert result is not None
+        assert "Salah" in result
+        assert "Rice" not in result  # round 2 — should be filtered out
+        assert "round 1" in result.lower()
+
+    def test_draft_picks_no_round_shows_all(self) -> None:
+        """Without a round mention, all picks should be shown."""
+        self.agent._session["league_id"] = 14204
+        self.agent._session["entry_id"] = 100
+        self.mcp.call_tool.return_value = {
+            "filtered_by": "My Team",
+            "picks": [
+                {"round": 1, "pick": 3, "entry_name": "Me", "player_name": "Salah", "team": "LIV", "position_type": 3},
+                {"round": 2, "pick": 14, "entry_name": "Me", "player_name": "Rice", "team": "ARS", "position_type": 3},
+            ],
+        }
+        result = self.agent._try_route("who did we draft", [])
+        assert result is not None
+        assert "Salah" in result
+        assert "Rice" in result
+
+    # ---- #85: "who won GW27" routes to league_summary ----
+
+    def test_who_won_gw_routes_to_league_summary(self) -> None:
+        """'who won GW27' should route to league_summary, not win_list (#85)."""
+        self.agent._session["league_id"] = 14204
+        self.mcp.call_tool.return_value = {
+            "entries": [], "gameweek": 27, "matches": [],
+        }
+        result = self.agent._try_route("who won gw27", [])
+        # Verify it called league_summary, not win_list
+        call_args = self.mcp.call_tool.call_args
+        assert call_args is not None
+        tool_name = call_args[0][0]
+        assert tool_name == "league_summary"
+
+    # ---- #86: "wins each gameweek" matches win_list ----
+
+    def test_wins_each_gameweek_matches_win_list(self) -> None:
+        """'wins each gameweek' should route to win_list (#86)."""
+        assert self.agent._looks_like("win_list", "wins each gameweek")
+
+    def test_wins_each_still_matches(self) -> None:
+        """The ('wins', 'each') tuple keyword should match."""
+        assert self.agent._looks_like("win_list", "my wins each week")
+
+    # ---- #87: "for" prefix stripped from player name ----
+
+    def test_player_name_for_prefix_stripped(self) -> None:
+        """'gameweek points for Saka' should extract 'Saka', not 'for Saka' (#87)."""
+        self.agent._session["league_id"] = 14204
+        self.mcp.call_tool.return_value = {
+            "player_name": "Saka", "team": "ARS", "position_type": 3,
+            "total_points": 50, "avg_points": 5.0, "gameweeks": [],
+        }
+        result = self.agent._try_route("gameweek points for Saka", [])
+        assert result is not None
+        # The tool should have been called with player_name="Saka" not "for Saka"
+        call_args = self.mcp.call_tool.call_args
+        tool_args = call_args[0][1]  # second positional arg is the args dict
+        assert tool_args.get("player_name") == "Saka"


### PR DESCRIPTION
## What changed

Fixes five chatbot routing and parameter-extraction bugs:

1. **#76 — `_default_entry_id()` config fallback**: Previously only checked session state. Now falls back to `SETTINGS.entry_id` so "my team"/"my roster" works from the first conversation turn without requiring an explicit entry_id in the session.

2. **#80 — Draft round filtering**: `_handle_draft_picks()` now extracts "round N" or "rd N" from user text and filters picks client-side. The Go MCP tool doesn't support a `round` input param, so filtering happens after the tool call.

3. **#85 — "who won GW27" routing**: Added a pre-check before `win_list` in `_try_route()` that detects "who" + "won" + GW reference and routes to `league_summary` instead of personal win history.

4. **#86 — "wins each gameweek" intent match**: Added `("wins", "each")` tuple to `win_list` keywords so "wins each gameweek" correctly matches the intent.

5. **#87 — "for" prefix in player name**: `_handle_player_gw_stats()` now strips a leading "for" left over after phrase removal, so "gameweek points for Saka" extracts "Saka" instead of "for Saka".

## Why

These are the final batch of chatbot bugs identified during manual testing. Each caused incorrect routing, missing data, or confusing responses.

## How to test

```bash
cd apps/backend
pytest tests/test_agent.py -v
ruff check .
```

Manual tests:
- "show my team" → should show roster (even without session entry_id)
- "who did we draft in round 1" → only round 1 picks
- "who won gw27" → league summary, not personal win list
- "wins each gameweek" → personal win list
- "gameweek points for Saka" → player stats for Saka

## Commands run

- `pytest tests/test_agent.py -v` — 58 passed
- `ruff check .` — all checks passed

## Risks / Edge cases

- Config fallback: `_default_entry_id()` now reads `SETTINGS.entry_id`. If SETTINGS has a stale or incorrect entry_id, it will be used as default. This mirrors how `_default_league_id()` already works.
- "who won" routing: The check `"who" in lower and "won" in lower and GW_PATTERN.search(lower)` is placed before `win_list` in routing order. If a user says "who won their gameweek matchup" it will route to league_summary. This is acceptable since the GW pattern ensures a specific gameweek is referenced.
- Client-side round filter is a linear scan over all picks, which is fine for draft leagues (typically <200 picks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)