### PR TITLE
feat: add game_status MCP tool for temporal awareness

### DIFF
--- a/apps/mcp-server/fpl-server/game_status.go
+++ b/apps/mcp-server/fpl-server/game_status.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GameStatusArgs is the input schema for game_status (no parameters).
+type GameStatusArgs struct{}
+
+// FixtureProgress tracks how many fixtures have started/finished in a GW.
+type FixtureProgress struct {
+	Total    int `json:"total"`
+	Started  int `json:"started"`
+	Finished int `json:"finished"`
+}
+
+// GameStatusResult is the output of the game_status tool.
+type GameStatusResult struct {
+	CurrentGW          int             `json:"current_gw"`
+	CurrentGWFinished  bool            `json:"current_gw_finished"`
+	NextGW             int             `json:"next_gw"`
+	WaiversProcessed   bool            `json:"waivers_processed"`
+	ProcessingStatus   string          `json:"processing_status"`
+	NextDeadline       string          `json:"next_deadline"`
+	NextWaiversDue     string          `json:"next_waivers_due"`
+	NextTradesDue      string          `json:"next_trades_due"`
+	NextGWFirstKickoff string          `json:"next_gw_first_kickoff,omitempty"`
+	CurrentGWFixtures  FixtureProgress `json:"current_gw_fixtures"`
+	PointsStatus       string          `json:"points_status"`
+}
+
+// gameStatusMeta extends GameMeta with additional fields from game.json.
+type gameStatusMeta struct {
+	CurrentEvent         int    `json:"current_event"`
+	CurrentEventFinished bool   `json:"current_event_finished"`
+	NextEvent            int    `json:"next_event"`
+	WaiversProcessed     bool   `json:"waivers_processed"`
+	ProcessingStatus     string `json:"processing_status"`
+}
+
+// bootstrapEvent represents one entry in events.data[] from bootstrap-static.json.
+type bootstrapEvent struct {
+	ID           int    `json:"id"`
+	Finished     bool   `json:"finished"`
+	DeadlineTime string `json:"deadline_time"`
+	WaiversTime  string `json:"waivers_time"`
+	TradesTime   string `json:"trades_time"`
+}
+
+// bootstrapFixture represents one fixture from bootstrap-static.json fixtures map.
+type bootstrapFixture struct {
+	ID          int    `json:"id"`
+	Event       int    `json:"event"`
+	KickoffTime string `json:"kickoff_time"`
+	Started     bool   `json:"started"`
+	Finished    bool   `json:"finished"`
+}
+
+// liveFixture is the subset of fields from a live.json fixture entry
+// needed for fixture progress tracking.
+type liveFixture struct {
+	ID       int  `json:"id"`
+	Event    int  `json:"event"`
+	Started  bool `json:"started"`
+	Finished bool `json:"finished"`
+}
+
+// loadLiveFixtures loads the fixtures array from gw/{gw}/live.json.
+func loadLiveFixtures(dataDir string, gw int) ([]liveFixture, error) {
+	path := filepath.Join(dataDir, "gw", strconv.Itoa(gw), "live.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var data struct {
+		Fixtures []liveFixture `json:"fixtures"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("parse gw/%d/live.json fixtures: %w", gw, err)
+	}
+	return data.Fixtures, nil
+}
+
+// loadGameStatusMeta reads game/game.json with the full set of status fields.
+func loadGameStatusMeta(cfg ServerConfig) (gameStatusMeta, error) {
+	path := fmt.Sprintf("%s/game/game.json", strings.TrimRight(cfg.RawRoot, "/"))
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return gameStatusMeta{}, err
+	}
+	var meta gameStatusMeta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return gameStatusMeta{}, err
+	}
+	return meta, nil
+}
+
+// loadBootstrapEvents reads events.data[] from bootstrap-static.json.
+func loadBootstrapEvents(rawRoot string) ([]bootstrapEvent, error) {
+	path := filepath.Join(rawRoot, "bootstrap", "bootstrap-static.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap-static.json: %w", err)
+	}
+	var resp struct {
+		Events struct {
+			Data []bootstrapEvent `json:"data"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("parse bootstrap events: %w", err)
+	}
+	return resp.Events.Data, nil
+}
+
+// loadBootstrapFixturesForGW reads fixtures[gw] from bootstrap-static.json.
+// Returns nil (no error) if the GW key is absent (bootstrap drops current GW once started).
+func loadBootstrapFixturesForGW(rawRoot string, gw int) ([]bootstrapFixture, error) {
+	path := filepath.Join(rawRoot, "bootstrap", "bootstrap-static.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap-static.json: %w", err)
+	}
+	var resp struct {
+		Fixtures map[string][]bootstrapFixture `json:"fixtures"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("parse bootstrap fixtures: %w", err)
+	}
+	return resp.Fixtures[strconv.Itoa(gw)], nil
+}
+
+// currentGWFixtureProgress counts started/finished fixtures for a GW.
+// Tries live.json first (bootstrap drops current GW once started),
+// falls back to bootstrap fixtures.
+func currentGWFixtureProgress(rawRoot string, gw int) FixtureProgress {
+	// Try live.json first (always has current GW data during/after matches).
+	liveFixtures, err := loadLiveFixtures(rawRoot, gw)
+	if err == nil && len(liveFixtures) > 0 {
+		progress := FixtureProgress{Total: len(liveFixtures)}
+		for _, f := range liveFixtures {
+			if f.Started {
+				progress.Started++
+			}
+			if f.Finished {
+				progress.Finished++
+			}
+		}
+		return progress
+	}
+
+	// Fall back to bootstrap fixtures (available before GW starts).
+	bsFixtures, err := loadBootstrapFixturesForGW(rawRoot, gw)
+	if err != nil || len(bsFixtures) == 0 {
+		return FixtureProgress{}
+	}
+	progress := FixtureProgress{Total: len(bsFixtures)}
+	for _, f := range bsFixtures {
+		if f.Started {
+			progress.Started++
+		}
+		if f.Finished {
+			progress.Finished++
+		}
+	}
+	return progress
+}
+
+// derivePointsStatus determines whether points are final, live, or pending.
+func derivePointsStatus(finished bool, fixtures FixtureProgress) string {
+	if finished {
+		return "final"
+	}
+	if fixtures.Started > 0 {
+		return "live"
+	}
+	return "pending"
+}
+
+// earliestKickoff finds the earliest kickoff_time from bootstrap fixtures for a GW.
+func earliestKickoff(rawRoot string, gw int) string {
+	fixtures, err := loadBootstrapFixturesForGW(rawRoot, gw)
+	if err != nil || len(fixtures) == 0 {
+		return ""
+	}
+	earliest := ""
+	for _, f := range fixtures {
+		if f.KickoffTime == "" {
+			continue
+		}
+		if earliest == "" || f.KickoffTime < earliest {
+			earliest = f.KickoffTime
+		}
+	}
+	return earliest
+}
+
+// buildGameStatus assembles the full game status response.
+func buildGameStatus(cfg ServerConfig) (*GameStatusResult, error) {
+	meta, err := loadGameStatusMeta(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("game.json: %w", err)
+	}
+
+	events, err := loadBootstrapEvents(cfg.RawRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the next unfinished event for deadline times.
+	var nextEvent *bootstrapEvent
+	for i := range events {
+		if !events[i].Finished {
+			nextEvent = &events[i]
+			break
+		}
+	}
+
+	result := &GameStatusResult{
+		CurrentGW:         meta.CurrentEvent,
+		CurrentGWFinished: meta.CurrentEventFinished,
+		NextGW:            meta.NextEvent,
+		WaiversProcessed:  meta.WaiversProcessed,
+		ProcessingStatus:  meta.ProcessingStatus,
+	}
+
+	if nextEvent != nil {
+		result.NextDeadline = nextEvent.DeadlineTime
+		result.NextWaiversDue = nextEvent.WaiversTime
+		result.NextTradesDue = nextEvent.TradesTime
+	}
+
+	result.NextGWFirstKickoff = earliestKickoff(cfg.RawRoot, meta.NextEvent)
+
+	result.CurrentGWFixtures = currentGWFixtureProgress(cfg.RawRoot, meta.CurrentEvent)
+
+	result.PointsStatus = derivePointsStatus(meta.CurrentEventFinished, result.CurrentGWFixtures)
+
+	return result, nil
+}
+
+// gameStatusHandler is the MCP tool handler for game_status.
+func gameStatusHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest, GameStatusArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args GameStatusArgs) (*mcp.CallToolResult, any, error) {
+		out, err := buildGameStatus(cfg)
+		if err != nil {
+			return toolError(err), nil, nil
+		}
+		return toolMarshal(out)
+	}
+}

--- a/apps/mcp-server/fpl-server/game_status_test.go
+++ b/apps/mcp-server/fpl-server/game_status_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// writeLiveFixtures writes gw/{gw}/live.json with the given fixtures.
+func writeLiveFixtures(t *testing.T, dir string, gw int, fixtures []any) {
+	t.Helper()
+	writeJSON(t, filepath.Join(dir, "gw", strconv.Itoa(gw), "live.json"), map[string]any{
+		"elements": map[string]any{},
+		"fixtures": fixtures,
+	})
+}
+
+// writeFullGameJSON writes game/game.json with all status fields.
+func writeFullGameJSON(t *testing.T, dir string, current int, finished bool, next int, waiversProcessed bool, processingStatus string) {
+	t.Helper()
+	writeJSON(t, filepath.Join(dir, "game", "game.json"), map[string]any{
+		"current_event":          current,
+		"current_event_finished": finished,
+		"next_event":             next,
+		"waivers_processed":      waiversProcessed,
+		"processing_status":      processingStatus,
+	})
+}
+
+// writeBootstrapEvents writes bootstrap-static.json with events and optional fixtures.
+func writeBootstrapEvents(t *testing.T, dir string, events []map[string]any, fixtures map[string]any) {
+	t.Helper()
+	if fixtures == nil {
+		fixtures = map[string]any{}
+	}
+	writeJSON(t, filepath.Join(dir, "bootstrap", "bootstrap-static.json"), map[string]any{
+		"events": map[string]any{
+			"data": events,
+		},
+		"fixtures": fixtures,
+		"elements": []any{},
+		"teams":    []any{},
+	})
+}
+
+func TestBuildGameStatus(t *testing.T) {
+	// Shared events for most tests: GW27 finished, GW28 not finished.
+	twoEvents := []map[string]any{
+		{"id": 27, "finished": true, "deadline_time": "2026-02-20T18:30:00Z", "waivers_time": "2026-02-19T18:30:00Z", "trades_time": "2026-02-18T18:30:00Z"},
+		{"id": 28, "finished": false, "deadline_time": "2026-02-27T18:30:00Z", "waivers_time": "2026-02-26T18:30:00Z", "trades_time": "2026-02-25T18:30:00Z"},
+	}
+
+	t.Run("FinishedGW", func(t *testing.T) {
+		dir, cfg := tmpCfg(t)
+		writeFullGameJSON(t, dir, 27, true, 28, true, "n")
+		writeBootstrapEvents(t, dir, twoEvents, map[string]any{
+			"28": []any{
+				map[string]any{"id": 280, "event": 28, "kickoff_time": "2026-02-27T20:00:00Z", "started": false, "finished": false},
+			},
+		})
+		// GW27 live.json with all fixtures finished.
+		writeLiveFixtures(t, dir, 27, []any{
+			map[string]any{"id": 261, "event": 27, "team_h": 1, "team_a": 2, "started": true, "finished": true},
+			map[string]any{"id": 262, "event": 27, "team_h": 3, "team_a": 4, "started": true, "finished": true},
+		})
+
+		out, err := buildGameStatus(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.PointsStatus != "final" {
+			t.Errorf("points_status=%q want final", out.PointsStatus)
+		}
+		if out.CurrentGWFinished != true {
+			t.Error("current_gw_finished should be true")
+		}
+		if out.NextDeadline != "2026-02-27T18:30:00Z" {
+			t.Errorf("next_deadline=%q want 2026-02-27T18:30:00Z", out.NextDeadline)
+		}
+		if out.NextGWFirstKickoff != "2026-02-27T20:00:00Z" {
+			t.Errorf("next_gw_first_kickoff=%q want 2026-02-27T20:00:00Z", out.NextGWFirstKickoff)
+		}
+	})
+
+	t.Run("LiveGW", func(t *testing.T) {
+		dir, cfg := tmpCfg(t)
+		writeFullGameJSON(t, dir, 28, false, 29, false, "n")
+		writeBootstrapEvents(t, dir, []map[string]any{
+			{"id": 27, "finished": true, "deadline_time": "2026-02-20T18:30:00Z", "waivers_time": "2026-02-19T18:30:00Z", "trades_time": "2026-02-18T18:30:00Z"},
+			{"id": 28, "finished": false, "deadline_time": "2026-02-27T18:30:00Z", "waivers_time": "2026-02-26T18:30:00Z", "trades_time": "2026-02-25T18:30:00Z"},
+			{"id": 29, "finished": false, "deadline_time": "2026-03-07T18:30:00Z", "waivers_time": "2026-03-06T18:30:00Z", "trades_time": "2026-03-05T18:30:00Z"},
+		}, map[string]any{
+			"29": []any{
+				map[string]any{"id": 290, "event": 29, "kickoff_time": "2026-03-07T20:00:00Z", "started": false, "finished": false},
+			},
+		})
+		// GW28 live.json: 3 started, 1 finished out of 5 total.
+		writeLiveFixtures(t, dir, 28, []any{
+			map[string]any{"id": 280, "event": 28, "team_h": 1, "team_a": 2, "started": true, "finished": true},
+			map[string]any{"id": 281, "event": 28, "team_h": 3, "team_a": 4, "started": true, "finished": false},
+			map[string]any{"id": 282, "event": 28, "team_h": 5, "team_a": 6, "started": true, "finished": false},
+			map[string]any{"id": 283, "event": 28, "team_h": 7, "team_a": 8, "started": false, "finished": false},
+			map[string]any{"id": 284, "event": 28, "team_h": 9, "team_a": 10, "started": false, "finished": false},
+		})
+
+		out, err := buildGameStatus(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.PointsStatus != "live" {
+			t.Errorf("points_status=%q want live", out.PointsStatus)
+		}
+		if out.CurrentGWFixtures.Total != 5 {
+			t.Errorf("total=%d want 5", out.CurrentGWFixtures.Total)
+		}
+		if out.CurrentGWFixtures.Started != 3 {
+			t.Errorf("started=%d want 3", out.CurrentGWFixtures.Started)
+		}
+		if out.CurrentGWFixtures.Finished != 1 {
+			t.Errorf("finished=%d want 1", out.CurrentGWFixtures.Finished)
+		}
+	})
+
+	t.Run("PendingGW", func(t *testing.T) {
+		dir, cfg := tmpCfg(t)
+		writeFullGameJSON(t, dir, 28, false, 29, true, "n")
+		writeBootstrapEvents(t, dir, []map[string]any{
+			{"id": 28, "finished": false, "deadline_time": "2026-02-27T18:30:00Z", "waivers_time": "2026-02-26T18:30:00Z", "trades_time": "2026-02-25T18:30:00Z"},
+		}, map[string]any{
+			"28": []any{
+				map[string]any{"id": 280, "event": 28, "kickoff_time": "2026-02-27T20:00:00Z", "started": false, "finished": false},
+				map[string]any{"id": 281, "event": 28, "kickoff_time": "2026-02-28T15:00:00Z", "started": false, "finished": false},
+			},
+		})
+
+		out, err := buildGameStatus(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.PointsStatus != "pending" {
+			t.Errorf("points_status=%q want pending", out.PointsStatus)
+		}
+		// Bootstrap fixtures available pre-kickoff.
+		if out.CurrentGWFixtures.Total != 2 {
+			t.Errorf("total=%d want 2", out.CurrentGWFixtures.Total)
+		}
+		if out.CurrentGWFixtures.Started != 0 {
+			t.Errorf("started=%d want 0", out.CurrentGWFixtures.Started)
+		}
+	})
+
+	t.Run("NextKickoffPicksEarliest", func(t *testing.T) {
+		dir, cfg := tmpCfg(t)
+		writeFullGameJSON(t, dir, 27, true, 28, true, "n")
+		writeBootstrapEvents(t, dir, twoEvents, map[string]any{
+			"28": []any{
+				map[string]any{"id": 282, "event": 28, "kickoff_time": "2026-02-28T15:00:00Z", "started": false, "finished": false},
+				map[string]any{"id": 280, "event": 28, "kickoff_time": "2026-02-27T20:00:00Z", "started": false, "finished": false},
+				map[string]any{"id": 281, "event": 28, "kickoff_time": "2026-02-28T12:30:00Z", "started": false, "finished": false},
+			},
+		})
+		writeLiveFixtures(t, dir, 27, []any{
+			map[string]any{"id": 261, "event": 27, "team_h": 1, "team_a": 2, "started": true, "finished": true},
+		})
+
+		out, err := buildGameStatus(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.NextGWFirstKickoff != "2026-02-27T20:00:00Z" {
+			t.Errorf("next_gw_first_kickoff=%q want 2026-02-27T20:00:00Z (earliest of 3)", out.NextGWFirstKickoff)
+		}
+	})
+
+	t.Run("MissingGameJSON", func(t *testing.T) {
+		_, cfg := tmpCfg(t)
+		_, err := buildGameStatus(cfg)
+		if err == nil {
+			t.Fatal("expected error for missing game.json")
+		}
+	})
+
+	t.Run("NoFixturesForGW", func(t *testing.T) {
+		dir, cfg := tmpCfg(t)
+		writeFullGameJSON(t, dir, 28, false, 29, false, "n")
+		// Bootstrap has events but no fixtures for GW28 (bootstrap dropped it).
+		// Also no live.json for GW28.
+		writeBootstrapEvents(t, dir, []map[string]any{
+			{"id": 28, "finished": false, "deadline_time": "2026-02-27T18:30:00Z", "waivers_time": "2026-02-26T18:30:00Z", "trades_time": "2026-02-25T18:30:00Z"},
+		}, nil)
+
+		out, err := buildGameStatus(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Graceful zero-value fixture progress.
+		if out.CurrentGWFixtures.Total != 0 {
+			t.Errorf("total=%d want 0 (no fixtures available)", out.CurrentGWFixtures.Total)
+		}
+		if out.PointsStatus != "pending" {
+			t.Errorf("points_status=%q want pending", out.PointsStatus)
+		}
+	})
+
+	t.Run("BootstrapDroppedCurrentGWFallsBackToLiveJSON", func(t *testing.T) {
+		// Bootstrap has dropped GW28 fixtures (happens once GW starts),
+		// but live.json has the fixture data. Verify we read from live.json.
+		dir, cfg := tmpCfg(t)
+		writeFullGameJSON(t, dir, 28, false, 29, false, "n")
+		writeBootstrapEvents(t, dir, []map[string]any{
+			{"id": 28, "finished": false, "deadline_time": "2026-02-27T18:30:00Z", "waivers_time": "2026-02-26T18:30:00Z", "trades_time": "2026-02-25T18:30:00Z"},
+		}, map[string]any{
+			// No "28" key — bootstrap has dropped it.
+			"29": []any{
+				map[string]any{"id": 290, "event": 29, "kickoff_time": "2026-03-07T20:00:00Z", "started": false, "finished": false},
+			},
+		})
+		// But live.json has the real data.
+		writeLiveFixtures(t, dir, 28, []any{
+			map[string]any{"id": 280, "event": 28, "team_h": 1, "team_a": 2, "started": true, "finished": true},
+			map[string]any{"id": 281, "event": 28, "team_h": 3, "team_a": 4, "started": true, "finished": false},
+		})
+
+		out, err := buildGameStatus(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.CurrentGWFixtures.Total != 2 {
+			t.Errorf("total=%d want 2 (from live.json fallback)", out.CurrentGWFixtures.Total)
+		}
+		if out.CurrentGWFixtures.Started != 2 {
+			t.Errorf("started=%d want 2", out.CurrentGWFixtures.Started)
+		}
+		if out.CurrentGWFixtures.Finished != 1 {
+			t.Errorf("finished=%d want 1", out.CurrentGWFixtures.Finished)
+		}
+		if out.PointsStatus != "live" {
+			t.Errorf("points_status=%q want live", out.PointsStatus)
+		}
+	})
+}

--- a/apps/mcp-server/fpl-server/main.go
+++ b/apps/mcp-server/fpl-server/main.go
@@ -435,6 +435,11 @@ func main() {
 		return toolMarshal(out)
 	})
 
+	addTool(server, &registry, &mcp.Tool{
+		Name:        "game_status",
+		Description: "Current game state: GW progress, deadlines (waivers/trades/lineup lock), fixture status, points finality",
+	}, gameStatusHandler(cfg))
+
 	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return server
 	}, &mcp.StreamableHTTPOptions{JSONResponse: true})


### PR DESCRIPTION
## What changed

New `game_status` MCP tool that gives the chatbot temporal awareness — answers "when are waivers due?", "are points final?", "when's the next game?" etc.

**New files:**
- `game_status.go` — stateless tool (no args) that reads `game.json` + `bootstrap-static.json` + `live.json` and returns current GW, deadlines, fixture progress, and points finality
- `game_status_test.go` — 7 test cases covering all game states

**Modified files:**
- `main.go` — tool registration + `toolMarshal` helper (used by game_status handler)
- `new_tools_test.go` — fix pre-existing `writeLeagueDetails` redeclaration bug (renamed to `writeLeagueDetailsFixture`)
- `transaction_analysis.go` — `go fmt` alignment only

### Tool output schema
```json
{
  "current_gw": 28,
  "current_gw_finished": false,
  "next_gw": 29,
  "waivers_processed": true,
  "processing_status": "n",
  "next_deadline": "2026-03-07T18:30:00Z",
  "next_waivers_due": "2026-03-06T18:30:00Z",
  "next_trades_due": "2026-03-05T18:30:00Z",
  "next_gw_first_kickoff": "2026-03-07T20:00:00Z",
  "current_gw_fixtures": { "total": 10, "started": 3, "finished": 1 },
  "points_status": "live"
}
```

## Why

The chatbot had zero temporal awareness — couldn't answer when waivers/trades are due, whether points are final or live, or when the next game kicks off. All this data was cached locally but never surfaced.

## How to test
```bash
cd apps/mcp-server && go fmt ./... && go vet ./... && go test ./...
```

## Commands run
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass (0.67s)

## Risks / Edge cases
- Bootstrap drops current GW fixtures once started → tool tries `live.json` first, falls back gracefully
- If `game.json` is missing, returns clear error
- If no fixtures exist for a GW, returns zero-value `FixtureProgress` (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)