### PR TITLE
ci: add env drift guardrail for .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,13 +69,13 @@ CACHE_REFRESH_ON_START=true
 #   go run ./apps/mcp-server/cmd/dev --refresh=all --league <LEAGUE_ID>
 # Example with a pre-built binary:
 #   CACHE_REFRESH_CMD_STARTUP=./bin/dev --refresh=all --league your-league-id
-# CACHE_REFRESH_CMD_STARTUP=
+CACHE_REFRESH_CMD_STARTUP=
 
 # ── Daily scheduled refresh ───────────────────────────────────────────────────
 
 # Optional: override the command used for the *daily scheduled* refresh.
 # Leave unset to use the auto-generated incremental command.
-# CACHE_REFRESH_CMD=go run ./apps/mcp-server/cmd/dev --refresh=scheduled --refresh-now --league your-league-id
+CACHE_REFRESH_CMD=
 
 # Re-run the cache refresh on a daily schedule (default: true).
 # The job fires at the time configured in CACHE_REFRESH_TIME.

--- a/.github/workflows/envdrift.yml
+++ b/.github/workflows/envdrift.yml
@@ -1,0 +1,19 @@
+name: Env Drift
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  envdrift:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Check .env.example drift
+        run: npx -y github:jszzr/envdrift#v0.1.0 . --example .env.example --include apps


### PR DESCRIPTION
## Summary
This PR adds a lightweight env drift check and aligns `.env.example` with env keys already referenced in code.

## Why
Issue #34 highlighted that `.env.example` can lag behind `config.py` settings. In practice, that creates onboarding friction and hidden runtime misconfiguration.

## Changes
- Add `CACHE_REFRESH_CMD_STARTUP=` and `CACHE_REFRESH_CMD=` entries to `.env.example`
- Add `.github/workflows/envdrift.yml` to check env drift on PR/push
- Env drift check runs with:
  - `npx -y github:jszzr/envdrift#v0.1.0 . --example .env.example --include apps`

## Result
This catches future regressions where env keys are used in `apps/*` code but not documented in `.env.example`.
