### PR TITLE
chore(flow): adopt trunk-based flow (feature → PR → main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,11 @@ name: CI
 
 on:
   push:
+    branches: [main]   # post-merge verification on trunk; PRs are the gate
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "0 6 * * 1"   # weekly keep-alive: also prevents GitHub's 60-day inactivity auto-disable
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,13 +1,8 @@
 name: Claude Review
 
-# Runs an automated Claude Code review on pull requests that move code between
-# the two gated branch transitions in this repo:
-#
-#   dev  →  stage   (integration gate)
-#   stage →  main   (production gate)
-#
-# Feature-branch PRs are intentionally excluded to keep token usage low.
-# Manual runs (workflow_dispatch) bypass the branch filter for testing.
+# Runs an automated Claude Code review on every pull request into main.
+# This repo uses trunk-based flow (feature branch -> PR -> main); the PR is the
+# single gate, so every PR gets a review.
 #
 # Required secret: CLAUDE_CODE_OAUTH_TOKEN (added automatically by the Claude GitHub App)
 # Install the app at: github.com/apps/claude  — or use ANTHROPIC_API_KEY as a fallback.
@@ -15,9 +10,7 @@ name: Claude Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    # Pre-filter to PRs targeting stage or main; the job-level `if` below
-    # further restricts to the exact source→target pairs we care about.
-    branches: [stage, main]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -29,11 +22,9 @@ jobs:
     name: Claude Code Review
     runs-on: ubuntu-latest
 
-    # Only run on the two branch transitions we care about.
-    # workflow_dispatch bypass lets you trigger a review manually for testing.
+    # Every PR into main gets a review; workflow_dispatch allows manual runs.
     if: |
-      (github.base_ref == 'stage' && github.head_ref == 'dev') ||
-      (github.base_ref == 'main'  && github.head_ref == 'stage') ||
+      github.base_ref == 'main' ||
       github.event_name == 'workflow_dispatch'
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,13 +82,18 @@ implications for agents working here right now:
 
 ## 3.2 Branching Rules
 
+This repo uses **trunk-based flow**: short-lived feature branch → PR → `main`.
+There are no `dev`/`stage` integration branches. The PR is the single gate:
+required status checks (Python 3.11/3.12, Go, gitleaks, artifacts-guard) +
+review must pass before merge; `main` runs post-merge CI.
+
 Branch naming:
 - `fix/<topic>`
 - `feat/<topic>`
 - `refactor/<topic>`
 - `chore/<topic>`
 
-Never work directly on `main`.
+Never work directly on `main`. Delete the feature branch after merge.
 
 ---
 
@@ -536,7 +541,7 @@ These rules are non-negotiable for all agents operating in this repo:
 
 - **Never call the live FPL API in tests.** Use fixtures in `t.TempDir()` (Go) or `tmp_path` (pytest).
 - **Never hardcode league IDs, entry IDs, or element IDs** in source code. Pass them as parameters.
-- **Never push directly to `main` or `dev`.** All changes must go through a PR.
+- **Never push directly to `main`.** All changes must go through a PR (trunk-based flow; there are no `dev`/`stage` branches).
 - **Never merge a PR with failing CI** (tests, lint, vet).
 - **Never add a `# type: ignore`** without a comment explaining why it's unavoidable.
 - **Never use `fmt.Sscanf` for float parsing** in Go — use `strconv.ParseFloat`.

--- a/STATE.md
+++ b/STATE.md
@@ -1,7 +1,7 @@
 # STATE — checkpoint
 
-Updated: 2026-07-29
-Branch: `feat/history-ingestion` (holds the foundation commits until you reorganize on push)
+Updated: 2026-07-30
+Branch model: **trunk-based** — feature branch -> PR -> `main` (dev/stage retired 2026-07-30; Docling-style).
 
 ## Done
 - Committed in-flight ML ingestion (Phase A) + reshape plan and model specs.
@@ -21,8 +21,14 @@ Branch: `feat/history-ingestion` (holds the foundation commits until you reorgan
 - Phase 2: season projection model (PROJECTION_MODEL_SPEC) that beats the eval
   baseline per position -> draft_board / draft_assistant / player_card tools.
 
-## Not done — needs you (outward-facing, not done locally)
-- Push branches / open PRs (nothing has been pushed).
-- Rotate `OPENAI_API_KEY`; set a real random `FPL_MCP_API_KEY`.
+## Done (CI/CD + branch model — 2026-07-30)
+- Fixed the 7-week CI failure (OverflowError dates); CI installs ML deps; re-enabled
+  the auto-disabled CI workflow; required status checks now gate `main` (strict).
+- PR #142 merged: full reshape foundation on `main`; main CI GREEN.
+- Branch cleanup: 44 remote branches -> main + dependabot. dev/stage retired;
+  Codex workflows deleted with stage. claude-review now gates every PR into main.
+
+## Not done — needs you (outward-facing)
+- Set a real random `FPL_MCP_API_KEY` (local .env still has the placeholder).
 - Uninstall the `chatgpt-codex-connector` GitHub App (GitHub settings).
-- Merge/close open PRs (#125, #115 safe; #137, #138 close; #122 request changes).
+- Dependabot PR triage (#125, #115 merge; #137, #138 close; #141, #135 judge; #122 request changes).


### PR DESCRIPTION
## What changed
- ci.yml: push trigger narrowed to main — PRs are the gate, push-to-main is post-merge verification (Docling-style)
- claude-review.yml: retargeted from the retired dev→stage→main transitions to every PR into main
- CLAUDE.md: branching rules document the trunk flow

## Why
dev/stage were unused since February (verified); Docling-style trunk + the hard PR gate on main replaces them. stage's deletion also removed the legacy Codex workflows.

## How to test
CI on this PR (all 5 required checks) + claude-review firing on a feature→main PR = the new model working.

## Commands run
yaml parse check; full local suite ran green on main pre-branch.

## Risks / Edge cases
Required-check contexts unchanged, so the gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)