### PR TITLE
feat(data): seasonized layout + element-status drop-radar (12-team league)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,8 +410,9 @@ fpl-draft-mcp/
 │           ├── config.py        # SETTINGS (env-backed)
 │           └── ml/              # Preseason next-season modeling (see ml/HISTORY_INGEST_SPEC.md)
 ├── data/                    # FPL raw + derived data (gitignored)
-│   ├── raw/                 # API snapshots (bootstrap.json, gw/*/live.json, etc.)
-│   └── derived/
+│   ├── raw/                 # LEGACY flat layout = the 2025-26 archive (do not overwrite)
+│   │   └── <season>/        # 2026-27 onward: season-nested (fetcher --season flag)
+│   └── derived/             # same convention: flat = 2025-26, <season>/ = new seasons
 │       ├── summary/         # league/standings/transactions summaries
 │       └── reports/         # GW markdown reports
 ├── CLAUDE.md

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,7 +8,7 @@ per section. Status: `[ ]` todo, `[~]` in progress, `[x]` done.
 ## Phase 0 — Foundation & declutter
 - [x] Commit in-flight work; remove stale worktrees; prune ephemeral branches (60 -> 5).
 - [x] Scaffold build-loop: architect (Fable) + reviewer (Opus) agents, `/build-loop` command, PLAN/STATE.
-- [ ] Disable Codex workflows on `stage` (branch `chore/disable-codex-ci` ready) and uninstall the Codex GitHub App; rotate keys. Acceptance: no Codex checks/comments on new PRs.
+- [x] Codex workflows removed (deleted with the retired stage branch); GitHub App uninstall still manual.
 
 ## Phase 1 — Data foundation  ✅ DONE (2026-07-29)
 - [x] Phase A ingest -> `player_seasons.parquet` (HISTORY_INGEST_SPEC). 5404 rows, 7 seasons; 5 tests pass.

--- a/STATE.md
+++ b/STATE.md
@@ -1,6 +1,6 @@
 # STATE — checkpoint
 
-Updated: 2026-07-30
+Updated: 2026-08-20
 Branch model: **trunk-based** — feature branch -> PR -> `main` (dev/stage retired 2026-07-30; Docling-style).
 
 ## Done
@@ -17,9 +17,21 @@ Branch model: **trunk-based** — feature branch -> PR -> `main` (dev/stage reti
   DEF/MID; per-90 alone loses. 15 ML tests; full suite 259 pass (1 pre-existing
   bug deselected, logged in ISSUES.md).
 
+## Done (Phase 2 model + new-league spine — 2026-08-20)
+- PR #144 merged: projection model + 26/27 draft board (394 players).
+- New 12-manager league verified against the live API (ids live in .env,
+  never tracked); league_size=12 in projection config (VOR regenerated).
+- Season-nested data layout (data/raw|derived/<season>/); 25/26 stays in the
+  legacy flat layout, untouched. First 26/27 fetch complete.
+- Fetcher: + league element-status (with timestamped snapshot archive),
+  element-summary, entry public/history endpoints.
+- Drop-radar (backend.ml.ownership): diffs snapshots -> ownership events;
+  ranked free-agent report (departed players filtered). 7 tests.
+
 ## Next
-- Phase 2: season projection model (PROJECTION_MODEL_SPEC) that beats the eval
-  baseline per position -> draft_board / draft_assistant / player_card tools.
+- Phase 3 weekly tools: waiver_plan (roster-aware add+drop using xP), my_week,
+  trade_check, league_pulse; match xP model (MATCH_MODEL_SPEC); schedule the
+  fetcher (fast mode) around waiver deadlines for fresh snapshots.
 
 ## Done (CI/CD + branch model — 2026-07-30)
 - Fixed the 7-week CI failure (OverflowError dates); CI installs ML deps; re-enabled

--- a/apps/backend/backend/ml/ownership.py
+++ b/apps/backend/backend/ml/ownership.py
@@ -1,0 +1,207 @@
+"""Drop-radar — turn league element-status snapshots into ownership intel.
+
+The fetcher archives timestamped snapshots of ``league/{id}/element-status``
+(every player's ``owner``: an entry id, or null = free agent). This module
+diffs consecutive snapshots into **ownership events** and ranks the current
+**free agents** by projected value — the two feeds a 12-team league lives on:
+
+* "who just got dropped" — an ``owner -> null`` transition, timestamped;
+* "which quality players went unclaimed after waivers" — free agents sorted
+  by next-season projection (from ``projections_2627``), so the post-waiver
+  sweep is a ranked list instead of a scroll through 400 names.
+
+Reads local files only (no live API calls). CLI:
+
+    python -m backend.ml.ownership --season 2026-27 --league 999999
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+POSITIONS = {1: "GKP", 2: "DEF", 3: "MID", 4: "FWD"}
+
+
+def load_snapshots(history_dir: Path) -> list[tuple[str, dict[int, int | None]]]:
+    """Load timestamped snapshots as (ts, {element_id: owner}) sorted by ts.
+
+    Snapshot filenames are ``<UTC ts>.json`` (e.g. ``20260820T0025.json``);
+    lexicographic order == chronological order.
+    """
+    snapshots = []
+    for path in sorted(Path(history_dir).glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        owners = {
+            int(row["element"]): row.get("owner")
+            for row in data.get("element_status", [])
+        }
+        snapshots.append((path.stem, owners))
+    return snapshots
+
+
+def diff_snapshots(
+    prev: dict[int, int | None], curr: dict[int, int | None], ts: str
+) -> list[dict[str, Any]]:
+    """Ownership events between two snapshots.
+
+    Event kinds: ``drop`` (owner -> free agent), ``add`` (free agent -> owner),
+    ``move`` (owner -> different owner, e.g. a trade). New elements appearing
+    mid-season with an owner also register as ``add``.
+    """
+    events: list[dict[str, Any]] = []
+    for element in sorted(set(prev) | set(curr)):
+        before = prev.get(element)
+        after = curr.get(element)
+        if before == after:
+            continue
+        kind = "move"
+        if before is not None and after is None:
+            kind = "drop"
+        elif before is None and after is not None:
+            kind = "add"
+        events.append({
+            "ts": ts, "element": element, "kind": kind,
+            "from_owner": before, "to_owner": after,
+        })
+    return events
+
+
+def build_events(snapshots: list[tuple[str, dict[int, int | None]]]) -> list[dict[str, Any]]:
+    """All ownership events across the full snapshot history (idempotent)."""
+    events: list[dict[str, Any]] = []
+    for (_, prev), (ts, curr) in zip(snapshots, snapshots[1:]):
+        events.extend(diff_snapshots(prev, curr, ts))
+    return events
+
+
+def _player_index(bootstrap: dict) -> dict[int, dict[str, Any]]:
+    """element id -> identity/context from that season's bootstrap."""
+    teams = {t["id"]: t.get("short_name") or t.get("name") for t in bootstrap.get("teams", [])}
+    index = {}
+    for el in bootstrap.get("elements", []):
+        index[el["id"]] = {
+            "code": el.get("code"),
+            "web_name": el.get("web_name"),
+            "position": POSITIONS.get(el.get("element_type")),
+            "team": teams.get(el.get("team")),
+            "status": el.get("status"),           # a=available, i=injured, ...
+            "news": el.get("news") or "",
+        }
+    return index
+
+
+def _projection_by_code(projections_path: Path) -> dict[int, dict[str, Any]]:
+    """code -> projection fields, if the projections file exists (else empty)."""
+    if not Path(projections_path).exists():
+        logger.warning("projections not found at %s; FA report will be unranked", projections_path)
+        return {}
+    rows = json.loads(Path(projections_path).read_text(encoding="utf-8"))
+    return {int(r["code"]): r for r in rows}
+
+
+def free_agent_report(
+    latest: dict[int, int | None],
+    bootstrap: dict,
+    projections_path: Path,
+    top_n: int = 15,
+) -> list[dict[str, Any]]:
+    """Free agents ranked by projected next-season points (per position mixed).
+
+    Players without a projection (e.g. promoted-team players) rank last but are
+    kept — availability flags and names still matter for the human scan.
+    """
+    players = _player_index(bootstrap)
+    projections = _projection_by_code(projections_path)
+    report = []
+    for element, owner in latest.items():
+        if owner is not None:
+            continue
+        info = players.get(element)
+        if info is None:
+            continue
+        if info["status"] == "u":
+            continue  # unavailable: left the league (transfer out) — not a real FA
+        projection = projections.get(info["code"], {})
+        report.append({
+            "element": element,
+            "web_name": info["web_name"],
+            "position": info["position"],
+            "team": info["team"],
+            "availability": info["status"],
+            "news": info["news"],
+            "projected_points": projection.get("projected_points"),
+            "tier": projection.get("tier"),
+            "confidence": projection.get("confidence"),
+        })
+    report.sort(key=lambda r: (r["projected_points"] is None,
+                               -(r["projected_points"] or 0)))
+    return report[:top_n]
+
+
+def annotate_events(events: list[dict[str, Any]], bootstrap: dict) -> list[dict[str, Any]]:
+    """Attach player identity to raw events for human-readable output."""
+    players = _player_index(bootstrap)
+    out = []
+    for event in events:
+        info = players.get(event["element"], {})
+        out.append({**event,
+                    "web_name": info.get("web_name"),
+                    "position": info.get("position"),
+                    "team": info.get("team")})
+    return out
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Drop-radar: ownership events + free-agent report")
+    parser.add_argument("--season", default="2026-27")
+    parser.add_argument("--league", type=int, required=True)
+    parser.add_argument("--top", type=int, default=15)
+    parser.add_argument("--raw-root", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    raw_root = args.raw_root or _repo_root() / "data/raw" / args.season
+    history_dir = raw_root / f"league/{args.league}/element_status_history"
+    bootstrap = json.loads((raw_root / "bootstrap/bootstrap-static.json").read_text(encoding="utf-8"))
+    projections_path = _repo_root() / "data/derived/ml/projections_2627.json"
+
+    snapshots = load_snapshots(history_dir)
+    if not snapshots:
+        logger.error("no snapshots in %s — run the fetcher first", history_dir)
+        return 1
+
+    events = annotate_events(build_events(snapshots), bootstrap)
+    out_path = args.out or _repo_root() / "data/derived" / args.season / "ml/ownership_events.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(events, indent=1))
+
+    print(f"\nsnapshots: {len(snapshots)} (latest {snapshots[-1][0]}) | events: {len(events)}")
+    recent = [e for e in events if e["ts"] == snapshots[-1][0]]
+    if recent:
+        print("\n== ownership changes in the latest snapshot ==")
+        for e in recent:
+            print(f"  {e['kind']:<5} {e['web_name']} ({e['position']}, {e['team']}) "
+                  f"{e['from_owner']} -> {e['to_owner']}")
+
+    print(f"\n== top {args.top} FREE AGENTS by projection ==")
+    for r in free_agent_report(snapshots[-1][1], bootstrap, projections_path, args.top):
+        pts = f"{r['projected_points']:.0f} pts" if r["projected_points"] is not None else "no projection"
+        flag = f"  [{r['availability']}] {r['news']}" if r["availability"] != "a" else ""
+        print(f"  {r['position']:<4} {r['web_name']:<20} {r['team']:<4} {pts:<14} "
+              f"tier={r['tier'] or '-'} {r['confidence'] or ''}{flag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend/backend/ml/projection.py
+++ b/apps/backend/backend/ml/projection.py
@@ -83,7 +83,7 @@ STAGE2_FEATURE_SETS: dict[str, dict[str, list[str]]] = {
 RIDGE_ALPHAS = [100.0, 30.0, 10.0, 3.0, 1.0, 0.3]
 
 # Draft config: league size and typical starters per position (configurable).
-DEFAULT_LEAGUE_SIZE = 10
+DEFAULT_LEAGUE_SIZE = 12
 DEFAULT_STARTERS = {"GKP": 1, "DEF": 4, "MID": 4, "FWD": 2}
 TIER_COUNT = 5
 

--- a/apps/backend/tests/test_ownership.py
+++ b/apps/backend/tests/test_ownership.py
@@ -1,0 +1,81 @@
+"""Tests for the drop-radar (backend.ml.ownership). No network — fixtures only."""
+
+import json
+
+from backend.ml import ownership as ow
+
+BOOTSTRAP = {
+    "elements": [
+        {"id": 10, "code": 100, "web_name": "Alpha", "element_type": 4, "team": 1,
+         "status": "a", "news": ""},
+        {"id": 20, "code": 200, "web_name": "Beta", "element_type": 3, "team": 1,
+         "status": "i", "news": "Knee injury"},
+        {"id": 30, "code": 300, "web_name": "Gamma", "element_type": 2, "team": 2,
+         "status": "a", "news": ""},
+    ],
+    "teams": [{"id": 1, "name": "Arsenal", "short_name": "ARS"},
+              {"id": 2, "name": "Hull City", "short_name": "HUL"}],
+}
+
+
+def test_diff_detects_drop_add_move():
+    prev = {10: 888888, 20: None, 30: 999}
+    curr = {10: None, 20: 888888, 30: 888}
+    events = ow.diff_snapshots(prev, curr, ts="20260821T1200")
+    kinds = {e["element"]: e["kind"] for e in events}
+    assert kinds == {10: "drop", 20: "add", 30: "move"}
+    drop = next(e for e in events if e["element"] == 10)
+    assert drop["from_owner"] == 888888 and drop["to_owner"] is None
+
+
+def test_diff_ignores_unchanged_and_handles_new_elements():
+    prev = {10: 1}
+    curr = {10: 1, 20: 2}  # 20 appears mid-season, already owned
+    events = ow.diff_snapshots(prev, curr, ts="t")
+    assert len(events) == 1
+    assert events[0] == {"ts": "t", "element": 20, "kind": "add",
+                         "from_owner": None, "to_owner": 2}
+
+
+def test_build_events_across_history_is_ordered():
+    snaps = [
+        ("t1", {10: None}),
+        ("t2", {10: 5}),      # add at t2
+        ("t3", {10: None}),   # drop at t3
+    ]
+    events = ow.build_events(snaps)
+    assert [(e["ts"], e["kind"]) for e in events] == [("t2", "add"), ("t3", "drop")]
+
+
+def test_free_agent_report_ranks_by_projection_and_keeps_unprojected(tmp_path):
+    latest = {10: None, 20: None, 30: 42}  # Gamma owned; Alpha+Beta free
+    projections = [{"code": 100, "projected_points": 120.0, "tier": 2, "confidence": "high"}]
+    proj_path = tmp_path / "projections.json"
+    proj_path.write_text(json.dumps(projections))
+
+    report = ow.free_agent_report(latest, BOOTSTRAP, proj_path, top_n=10)
+    assert [r["web_name"] for r in report] == ["Alpha", "Beta"]  # projected first
+    assert report[0]["projected_points"] == 120.0
+    assert report[1]["projected_points"] is None                 # kept, ranked last
+    assert report[1]["availability"] == "i" and "Knee" in report[1]["news"]
+
+
+def test_free_agent_report_without_projections_file(tmp_path):
+    report = ow.free_agent_report({10: None}, BOOTSTRAP, tmp_path / "missing.json")
+    assert len(report) == 1 and report[0]["projected_points"] is None
+
+
+def test_annotate_events_attaches_identity():
+    events = [{"ts": "t", "element": 20, "kind": "drop", "from_owner": 1, "to_owner": None}]
+    out = ow.annotate_events(events, BOOTSTRAP)
+    assert out[0]["web_name"] == "Beta" and out[0]["position"] == "MID" and out[0]["team"] == "ARS"
+
+
+def test_free_agent_report_excludes_departed_players(tmp_path):
+    bootstrap = {
+        "elements": [{"id": 40, "code": 400, "web_name": "GonePlayer", "element_type": 4,
+                      "team": 1, "status": "u", "news": "Has joined Como permanently"}],
+        "teams": [{"id": 1, "name": "Arsenal", "short_name": "ARS"}],
+    }
+    report = ow.free_agent_report({40: None}, bootstrap, tmp_path / "missing.json")
+    assert report == []

--- a/apps/mcp-server/cmd/dev/main.go
+++ b/apps/mcp-server/cmd/dev/main.go
@@ -46,10 +46,21 @@ func main() {
 		reconcileOn     = flag.Bool("reconcile", true, "compare draft ledger vs snapshots and write mismatch report")
 		summaryHorizons = flag.String("summary-horizons", "5,10,20", "comma-separated horizons in GWs for summaries")
 		summaryRisks    = flag.String("summary-risks", "low,med,high", "comma-separated risk levels for summaries")
+		season          = flag.String("season", "", "season label (e.g. 2026-27): nests raw/derived roots as <root>/<season>. Empty = legacy flat layout (the 2025-26 archive) — pass it for all new-season fetches so old seasons are never overwritten")
+		elementStatus   = flag.Bool("element-status", true, "fetch league element-status (ownership) and archive a timestamped snapshot for the drop-radar")
 	)
 	flag.Parse()
 
-	st := store.NewJSONStore(*rawRoot)
+	// Season-nested layout: data/raw/<season>/... and data/derived/<season>/...
+	// keeps each season's data isolated (the flat legacy layout holds 2025-26).
+	rawDir := *rawRoot
+	derivedDir := *derivedRoot
+	if *season != "" {
+		rawDir = filepath.Join(*rawRoot, *season)
+		derivedDir = filepath.Join(derivedDir, *season)
+	}
+
+	st := store.NewJSONStore(rawDir)
 	client := fetch.NewClient(st)
 	client.PrettyWrite = *pretty && !*live
 	client.Sleep = time.Duration(*sleepMS) * time.Millisecond
@@ -106,15 +117,18 @@ func main() {
 		must(client.LeagueTransactions(*leagueID, refreshTransactions))
 		must(client.LeagueTrades(*leagueID, refreshTransactions))
 		must(client.LeagueDetails(*leagueID, refreshLeagueDetails))
+		if *elementStatus {
+			must(snapshotElementStatus(client, *leagueID, now))
+		}
 		if client.DisableWrite {
 			log.Println("fast refresh complete (live mode)")
 			return
 		}
-		if err := summary.BuildTransactionsSummary(st, *derivedRoot, *leagueID, game.CurrentEvent); err != nil {
+		if err := summary.BuildTransactionsSummary(st, derivedDir, *leagueID, game.CurrentEvent); err != nil {
 			log.Printf("derive-transactions failed: %v", err)
 		}
 		if game.WaiversProcessed && game.NextEvent > game.CurrentEvent {
-			if err := summary.BuildTransactionsSummary(st, *derivedRoot, *leagueID, game.NextEvent); err != nil {
+			if err := summary.BuildTransactionsSummary(st, derivedDir, *leagueID, game.NextEvent); err != nil {
 				log.Printf("derive-next-transactions failed: %v", err)
 			} else {
 				log.Printf("derived transactions for GW %d\n", game.NextEvent)
@@ -129,6 +143,9 @@ func main() {
 	must(client.LeagueTransactions(*leagueID, refreshTransactions))
 	must(client.LeagueTrades(*leagueID, refreshTransactions))
 	must(client.LeagueDetails(*leagueID, refreshLeagueDetails))
+	if *elementStatus {
+		must(snapshotElementStatus(client, *leagueID, now))
+	}
 
 	// Read league details from disk to get entry IDs.
 	ldPath := fmt.Sprintf("league/%d/details.json", *leagueID)
@@ -143,6 +160,8 @@ func main() {
 		entryIDs = append(entryIDs, e.EntryID)
 	}
 	log.Printf("Found %d entry IDs\n", len(entryIDs))
+
+	must(fetchEntryMeta(client, entryIDs, refreshLeagueDetails))
 
 	minGW := *gwMin
 	maxGW := *gwMax
@@ -164,7 +183,7 @@ func main() {
 		if client.DisableWrite {
 			log.Println("derive-draft skipped in live mode")
 		} else {
-			must(buildDraftLedger(st, *derivedRoot, *leagueID))
+			must(buildDraftLedger(st, derivedDir, *leagueID))
 		}
 	}
 
@@ -172,7 +191,7 @@ func main() {
 		if client.DisableWrite {
 			log.Println("derive-snapshots skipped in live mode")
 		} else {
-			must(buildEntrySnapshots(st, *derivedRoot, *leagueID, entryIDs, minGW, maxGW))
+			must(buildEntrySnapshots(st, derivedDir, *leagueID, entryIDs, minGW, maxGW))
 		}
 	}
 
@@ -180,14 +199,14 @@ func main() {
 		if client.DisableWrite {
 			log.Println("reconcile skipped in live mode")
 		} else {
-			must(buildReconcileReports(st, *derivedRoot, *leagueID, entryIDs, minGW, maxGW))
+			must(buildReconcileReports(st, derivedDir, *leagueID, entryIDs, minGW, maxGW))
 		}
 	}
 
 	if client.DisableWrite {
 		log.Println("derive-points skipped in live mode")
 	} else {
-		must(buildPointsResults(st, *derivedRoot, *leagueID, entryIDs, minGW, maxGW))
+		must(buildPointsResults(st, derivedDir, *leagueID, entryIDs, minGW, maxGW))
 	}
 
 	if client.DisableWrite {
@@ -196,9 +215,9 @@ func main() {
 		horizons, err := summary.ParseHorizons(*summaryHorizons)
 		must(err)
 		riskLevels := summary.ParseRiskLevels(*summaryRisks)
-		must(summary.BuildLeagueSummaries(st, *derivedRoot, *leagueID, ld, entryIDs, minGW, maxGW, horizons, riskLevels))
+		must(summary.BuildLeagueSummaries(st, derivedDir, *leagueID, ld, entryIDs, minGW, maxGW, horizons, riskLevels))
 		if game.WaiversProcessed && game.NextEvent > game.CurrentEvent {
-			if err := summary.BuildTransactionsSummary(st, *derivedRoot, *leagueID, game.NextEvent); err != nil {
+			if err := summary.BuildTransactionsSummary(st, derivedDir, *leagueID, game.NextEvent); err != nil {
 				log.Printf("derive-next-transactions failed: %v", err)
 			} else {
 				log.Printf("derived transactions for GW %d\n", game.NextEvent)
@@ -207,6 +226,33 @@ func main() {
 	}
 
 	log.Println("Done.")
+}
+
+// snapshotElementStatus fetches the league's element-status (ownership of
+// every player: owner entry id or null = free agent) and archives a
+// timestamped copy. Always forced — ownership is a live snapshot, and the
+// timestamped history is what the drop-radar diffs into ownership events.
+func snapshotElementStatus(client *fetch.Client, leagueID int, now time.Time) error {
+	body, err := client.LeagueElementStatus(leagueID, true)
+	if err != nil {
+		return err
+	}
+	ts := now.UTC().Format("20060102T1504")
+	return client.ArchiveElementStatus(leagueID, body, ts)
+}
+
+// fetchEntryMeta fetches each manager's public profile and per-GW history.
+// Cheap (2 calls per entry) and useful for league_pulse / opponent context.
+func fetchEntryMeta(client *fetch.Client, entryIDs []int, force bool) error {
+	for _, entryID := range entryIDs {
+		if err := client.EntryPublic(entryID, force); err != nil {
+			return err
+		}
+		if err := client.EntryHistory(entryID, force); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Scheduled refresh window:

--- a/apps/mcp-server/internal/fetch/endpoints.go
+++ b/apps/mcp-server/internal/fetch/endpoints.go
@@ -76,3 +76,59 @@ func (c *Client) EntryEvent(entryID int, gw int, force bool) error {
 	)
 	return err
 }
+
+// /league/{league_id}/element-status — ownership of every element in a draft
+// league: owner (entry id or null = free agent), waiver status, trade flag.
+// This is the feed for the drop-radar: latest.json is overwritten each fetch,
+// and ArchiveElementStatus keeps timestamped snapshots for diffing.
+func (c *Client) LeagueElementStatus(leagueID int, force bool) ([]byte, error) {
+	return c.FetchRaw(
+		fmt.Sprintf("/league/%d/element-status", leagueID),
+		fmt.Sprintf("league/%d/element-status.json", leagueID),
+		force,
+	)
+}
+
+// ArchiveElementStatus writes an already-fetched element-status body to a
+// timestamped snapshot path (UTC, minute precision) so consecutive snapshots
+// can be diffed into ownership events (drops, adds, trades).
+func (c *Client) ArchiveElementStatus(leagueID int, body []byte, ts string) error {
+	if c.DisableWrite {
+		return nil
+	}
+	return c.Store.WriteRaw(
+		fmt.Sprintf("league/%d/element_status_history/%s.json", leagueID, ts),
+		body,
+		c.PrettyWrite,
+	)
+}
+
+// /element-summary/{element_id} — per-player upcoming fixtures + per-GW history.
+func (c *Client) ElementSummary(elementID int, force bool) error {
+	_, err := c.FetchRaw(
+		fmt.Sprintf("/element-summary/%d", elementID),
+		fmt.Sprintf("element-summary/%d.json", elementID),
+		force,
+	)
+	return err
+}
+
+// /entry/{entry_id}/public — public profile for a manager entry.
+func (c *Client) EntryPublic(entryID int, force bool) error {
+	_, err := c.FetchRaw(
+		fmt.Sprintf("/entry/%d/public", entryID),
+		fmt.Sprintf("entry/%d/public.json", entryID),
+		force,
+	)
+	return err
+}
+
+// /entry/{entry_id}/history — per-GW points history for a manager entry.
+func (c *Client) EntryHistory(entryID int, force bool) error {
+	_, err := c.FetchRaw(
+		fmt.Sprintf("/entry/%d/history", entryID),
+		fmt.Sprintf("entry/%d/history.json", entryID),
+		force,
+	)
+	return err
+}


### PR DESCRIPTION
## What changed
- Fetcher: `--season` flag nests raw/derived under `<root>/<season>` — the flat legacy layout is the 2025-26 archive and can no longer be overwritten by new-season fetches
- Fetcher: `--element-status` fetches league ownership + archives timestamped snapshots (fast and full paths); new endpoints: element-status, element-summary, entry public/history
- `backend.ml.ownership` (drop-radar): diffs snapshots into ownership events (drop/add/move) + a ranked free-agent report (projection-ranked, departed players filtered, injury flags inline). 7 no-network tests
- `DEFAULT_LEAGUE_SIZE` 10 → 12 for the new league; projections/VOR regenerated
- Docs: CLAUDE.md data-layout convention, STATE.md, PLAN.md

## Why
The new 12-team league leaves a much thinner FA pool — dropped-player monitoring and the post-waiver sweep become the highest-value weekly signals. This is the data spine for waiver_plan. League/entry ids are env-only, per repo policy.

## How to test
`pytest apps/backend/tests/test_ownership.py` (7 tests). Live-verified locally: first 2026-27 fetch complete (owned count = league size × 15 exactly), drop-radar produces a clean ranked FA report, 25/26 archive untouched.

## Commands run
pytest (279 passed), ruff (clean), gofmt/go vet/go test (clean), real fetch + radar run.

## Risks / Edge cases
Legacy flat layout intentionally untouched (Python ML defaults read it for 25/26). Events appear from the second snapshot onward. Departed players (status=u) excluded from the FA report by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)