### PR TITLE
feat: waiver_plan + MCP serving layer (draft_board, player_card, waiver_plan, drop_radar)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,8 @@ fpl-draft-mcp/
 │   │   │   ├── dev/                     # the ONLY component that hits the live FPL API
 │   │   │   └── schema-inventory/        # dev utility: dumps API schema registry
 │   │   └── fpl-server/
-│   │       ├── main.go                  # Entry point, registers all 26 tools, auth, /mcp
+│   │       ├── main.go                  # Entry point, registers all 30 tools, auth, /mcp
+│   │       ├── draft_tools.go           # Decision layer: draft_board, player_card, waiver_plan, drop_radar (serve ML artifacts)
 │   │       ├── waiver_recommendations.go# Waiver scoring logic
 │   │       ├── fixture_difficulty.go    # FDR calculations
 │   │       ├── head_to_head.go          # H2H record tool
@@ -432,7 +433,7 @@ Scheduler (Python, APScheduler)
   ▼
 Go MCP Server (:8080)
   │  reads data/raw/ + derived/
-  │  exposes 26 tools via MCP protocol
+  │  exposes 30 tools via MCP protocol
   ▼
 Python Agent (backend/agent.py)
   │  receives user message

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An end-to-end **Fantasy Premier League Draft** toolkit.  Ask any question about your league in natural language — the agent calls the right data tools and returns a clear, structured answer.
 
 The stack is:
-- **Go MCP server** — exposes 26 tools backed by locally-cached FPL Draft API data
+- **Go MCP server** — exposes 30 tools backed by locally-cached FPL Draft API data
 - **Python backend** — chat API, scheduled reports, and a WebSocket endpoint
 - **Web UI** — chat interface with tool-call visibility and one-click report generation
 

--- a/STATE.md
+++ b/STATE.md
@@ -28,10 +28,19 @@ Branch model: **trunk-based** — feature branch -> PR -> `main` (dev/stage reti
 - Drop-radar (backend.ml.ownership): diffs snapshots -> ownership events;
   ranked free-agent report (departed players filtered). 7 tests.
 
+## Done (waiver_plan v1 — 2026-08-20)
+- backend.ml.waiver: roster-aware add/drop CLI. Squad eval (best legal XI by
+  next-3 xP), per-GW baseline from the season projection, fixture multiplier
+  from 25/26 team strengths (promoted prior), live availability gating
+  (next-3 only — ROS survives injuries), and explicit short-vs-long balance:
+  every rec shows next3_gain AND season_gain with upgrade/stream/hold labels.
+  9 no-network tests; live-run verified against the real league.
+
 ## Next
-- Phase 3 weekly tools: waiver_plan (roster-aware add+drop using xP), my_week,
-  trade_check, league_pulse; match xP model (MATCH_MODEL_SPEC); schedule the
-  fetcher (fast mode) around waiver deadlines for fresh snapshots.
+- my_week (start/sit from the same xP core), trade_check, league_pulse;
+  match xP model (MATCH_MODEL_SPEC) replaces the per-GW baseline once GWs
+  accumulate; MCP tool wrappers for Claude Desktop; schedule fast-mode fetches
+  around waiver deadlines.
 
 ## Done (CI/CD + branch model — 2026-07-30)
 - Fixed the 7-week CI failure (OverflowError dates); CI installs ML deps; re-enabled

--- a/STATE.md
+++ b/STATE.md
@@ -36,11 +36,20 @@ Branch model: **trunk-based** — feature branch -> PR -> `main` (dev/stage reti
   every rec shows next3_gain AND season_gain with upgrade/stream/hold labels.
   9 no-network tests; live-run verified against the real league.
 
+## Done (serving layer — 2026-08-20)
+- Go decision tools live on the MCP server (30 total): draft_board,
+  player_card (projection + multi-season history + live news — the reversion
+  safeguard), waiver_plan, drop_radar. --default-season flag; 5 Go tests.
+- serve_export writes player_history.json (2108 players); jsonutil.dumps_strict
+  fixes NaN-poisoned artifacts (Go strict JSON) — both writers routed through it.
+- Verified end-to-end over real MCP (initialize -> tools/call).
+- docs/CLAUDE_DESKTOP.md: connector setup + the weekly artifact-refresh loop.
+
 ## Next
-- my_week (start/sit from the same xP core), trade_check, league_pulse;
-  match xP model (MATCH_MODEL_SPEC) replaces the per-GW baseline once GWs
-  accumulate; MCP tool wrappers for Claude Desktop; schedule fast-mode fetches
-  around waiver deadlines.
+- my_week (start/sit), trade_check, league_pulse; match xP model replaces the
+  per-GW baseline as GWs accumulate; schedule fast-mode fetches around waiver
+  deadlines; doc-hygiene sweep from the evaluation report (CLAUDE.md OpenAI
+  sections, PLAN Phase-2 ticks, spec header reconciliation).
 
 ## Done (CI/CD + branch model — 2026-07-30)
 - Fixed the 7-week CI failure (OverflowError dates); CI installs ML deps; re-enabled

--- a/apps/backend/backend/ml/jsonutil.py
+++ b/apps/backend/backend/ml/jsonutil.py
@@ -1,0 +1,29 @@
+"""Strict-JSON helpers shared by the ML pipeline writers.
+
+Python's ``json.dumps`` emits bare ``NaN`` for float('nan'), which is invalid
+JSON and rejected by strict parsers (including Go's encoding/json — the
+serving layer). Every artifact consumed by the Go tools must be written
+through :func:`dumps_strict`, which converts NaN/Inf to null and refuses to
+emit non-finite literals.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {k: _sanitize(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_sanitize(v) for v in value]
+    return value
+
+
+def dumps_strict(value: Any, **kwargs: Any) -> str:
+    """json.dumps with NaN/Inf replaced by null; guaranteed strict-parseable."""
+    return json.dumps(_sanitize(value), allow_nan=False, **kwargs)

--- a/apps/backend/backend/ml/projection.py
+++ b/apps/backend/backend/ml/projection.py
@@ -40,6 +40,7 @@ import numpy as np
 import pandas as pd
 
 from backend.ml import features as F
+from backend.ml import jsonutil
 
 logger = logging.getLogger(__name__)
 
@@ -561,7 +562,7 @@ def main(argv: list[str] | None = None) -> int:
         out_parquet = args.out_dir / "projections_2627.parquet"
         board.to_parquet(out_parquet, index=False)
         out_json = args.out_dir / "projections_2627.json"
-        out_json.write_text(json.dumps(board.to_dict(orient="records"), indent=1))
+        out_json.write_text(jsonutil.dumps_strict(board.to_dict(orient="records"), indent=1))
         logger.info("wrote %d projections -> %s (+ .json for Go tools)",
                     len(board), out_parquet)
     return 0

--- a/apps/backend/backend/ml/serve_export.py
+++ b/apps/backend/backend/ml/serve_export.py
@@ -1,0 +1,65 @@
+"""Export serving artifacts for the Go decision tools.
+
+Writes ``data/derived/ml/player_history.json`` — every player's multi-season
+history keyed by permanent ``code`` — from ``player_seasons.parquet``. The Go
+``player_card`` tool shows this next to the projection so a one-season dip or
+spike (the Salah case) is always visible to the human making the call.
+
+Run after any ingest refresh: ``python -m backend.ml.serve_export``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+HISTORY_COLUMNS = ["season", "team_name", "minutes", "total_points",
+                   "goals_scored", "assists", "expected_goals", "expected_assists"]
+
+
+def build_history(seasons: pd.DataFrame) -> dict[str, list[dict]]:
+    """code (as str, JSON-object key) -> chronological season rows."""
+    out: dict[str, list[dict]] = {}
+    frame = seasons.sort_values(["code", "season"])
+    for code, group in frame.groupby("code"):
+        rows = []
+        for _, r in group.iterrows():
+            row = {}
+            for col in HISTORY_COLUMNS:
+                value = r.get(col)
+                row[col] = None if pd.isna(value) else (
+                    value if isinstance(value, str) else float(value))
+            rows.append(row)
+        out[str(int(code))] = rows
+    return out
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Export player_history.json for the Go tools")
+    parser.add_argument("--parquet", type=Path,
+                        default=_repo_root() / "data/derived/ml/player_seasons.parquet")
+    parser.add_argument("--out", type=Path,
+                        default=_repo_root() / "data/derived/ml/player_history.json")
+    args = parser.parse_args(argv)
+
+    seasons = pd.read_parquet(args.parquet)
+    history = build_history(seasons)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(history))
+    logger.info("wrote history for %d players -> %s", len(history), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend/backend/ml/waiver.py
+++ b/apps/backend/backend/ml/waiver.py
@@ -1,0 +1,304 @@
+"""waiver_plan — roster-aware add/drop recommendations.
+
+Answers the weekly question: *given MY squad and MY league's free agents, who
+do I add, who do I drop, and is the move a short-term stream or a season-long
+upgrade?* Reads local files only (bootstrap, element-status snapshot,
+projections, the 25/26 season table) — no live API calls.
+
+Design (v1, pre-GW1-honest):
+
+* **Per-GW baseline** = season projection / 38 (the measured-vs-baseline model
+  from ``projection.py``). Early season there is no current form to use; as the
+  match xP model (MATCH_MODEL_SPEC) lands, it replaces this baseline.
+* **Fixture adjustment** — opponent strength from last season's per-team player
+  points totals (promoted teams get a weak prior: 90% of the minimum), mapped
+  to a multiplier in [0.85, 1.15], with a small home/away nudge. Summing per
+  event handles blanks (0 fixtures) and doubles (2) naturally.
+* **Availability gate** — live status/news from bootstrap: available=1.0,
+  doubtful=chance/100, injured/suspended=chance if stated else 0, departed=0.
+* **The short-vs-long balance is explicit**: every candidate shows
+  ``next3_gain`` (points over the next 3 GWs vs the drop candidate) AND
+  ``season_gain`` (rest-of-season vs the same drop). Labels:
+  ``upgrade`` (both positive — add and hold), ``stream`` (helps now, worse
+  long-term — plan to re-drop), ``hold`` (worse now, better over the season —
+  patience play). A class player with two tough fixtures shows a small/negative
+  next3_gain but a big season_gain — and stays recommended as ``hold``.
+
+CLI: python -m backend.ml.waiver --league <id> --entry <id>   (env fallback:
+LEAGUE_ID / ENTRY_ID)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+POSITIONS = {1: "GKP", 2: "DEF", 3: "MID", 4: "FWD"}
+NEXT_GWS = 3
+TOTAL_GWS = 38
+# Fixture multiplier bounds and home nudge (documented, deliberately mild —
+# fixtures modulate quality, they don't replace it).
+FIXTURE_MULT_MIN, FIXTURE_MULT_MAX = 0.85, 1.15
+HOME_NUDGE = 1.03
+# Valid draft formations: (DEF, MID, FWD) with exactly 1 GKP, 10 outfielders.
+FORMATIONS = [(3, 4, 3), (3, 5, 2), (4, 3, 3), (4, 4, 2), (4, 5, 1), (5, 3, 2), (5, 4, 1)]
+
+
+# ---------------------------------------------------------------------------
+# Building blocks
+# ---------------------------------------------------------------------------
+
+def team_strengths(seasons: pd.DataFrame, teams: list[dict]) -> dict[int, float]:
+    """26/27 team id -> strength score (sum of that club's player points in
+    25/26). Promoted/unseen clubs get a weak prior: 90% of the minimum."""
+    last = seasons[seasons["season"] == "2025-26"]
+    by_name = last.groupby("team_name")["total_points"].sum().to_dict()
+    floor = 0.9 * min(by_name.values()) if by_name else 0.0
+    return {t["id"]: float(by_name.get(t["name"], floor)) for t in teams}
+
+
+def fixture_multiplier(opponent_strength: float, strengths: dict[int, float],
+                       is_home: bool) -> float:
+    """Mild multiplier: weakest opponent -> ~1.15, strongest -> ~0.85."""
+    values = sorted(strengths.values())
+    lo, hi = values[0], values[-1]
+    span = (hi - lo) or 1.0
+    # opponent strong -> harder fixture -> below 1
+    centered = 0.5 - (opponent_strength - lo) / span  # +0.5 weakest .. -0.5 strongest
+    mult = 1.0 + centered * (FIXTURE_MULT_MAX - FIXTURE_MULT_MIN)
+    mult *= HOME_NUDGE if is_home else (2 - HOME_NUDGE)
+    return max(FIXTURE_MULT_MIN, min(FIXTURE_MULT_MAX, mult))
+
+
+def next_fixture_load(bootstrap: dict, strengths: dict[int, float],
+                      n_events: int = NEXT_GWS) -> dict[int, float]:
+    """team id -> summed fixture multiplier over the next n events.
+
+    ``bootstrap['fixtures']`` is a dict keyed by event number holding that
+    event's fixtures; a team appearing 0/1/2 times in an event is a blank /
+    normal / double gameweek and the sum reflects it automatically.
+    """
+    load: dict[int, float] = {t["id"]: 0.0 for t in bootstrap.get("teams", [])}
+    fixtures_by_event = bootstrap.get("fixtures", {}) or {}
+    events = sorted(int(e) for e in fixtures_by_event)[:n_events]
+    for event in events:
+        for fx in fixtures_by_event[str(event)]:
+            home, away = fx.get("team_h"), fx.get("team_a")
+            if home in load:
+                load[home] += fixture_multiplier(strengths.get(away, 0.0), strengths, True)
+            if away in load:
+                load[away] += fixture_multiplier(strengths.get(home, 0.0), strengths, False)
+    return load
+
+
+def availability_factor(element: dict) -> float:
+    """Live availability gate from bootstrap status/news flags."""
+    status = element.get("status", "a")
+    chance = element.get("chance_of_playing_next_round")
+    if status == "a":
+        return 1.0
+    if status == "u":
+        return 0.0
+    if chance is not None:
+        return max(0.0, min(1.0, float(chance) / 100.0))
+    return 0.75 if status == "d" else 0.0
+
+
+def build_player_table(bootstrap: dict, seasons: pd.DataFrame,
+                       projections_path: Path) -> pd.DataFrame:
+    """One row per 26/27 element: identity, availability, next-3 xP, ROS value."""
+    strengths = team_strengths(seasons, bootstrap.get("teams", []))
+    load = next_fixture_load(bootstrap, strengths)
+    projections = {}
+    if Path(projections_path).exists():
+        projections = {int(r["code"]): r for r in
+                       json.loads(Path(projections_path).read_text(encoding="utf-8"))}
+    else:
+        logger.warning("projections missing at %s — values will be null", projections_path)
+
+    team_names = {t["id"]: t.get("short_name") or t.get("name")
+                  for t in bootstrap.get("teams", [])}
+    rows = []
+    for el in bootstrap.get("elements", []):
+        projection = projections.get(el.get("code"), {})
+        ros = projection.get("projected_points")
+        avail = availability_factor(el)
+        per_gw = (ros / TOTAL_GWS) if ros is not None else None
+        next3 = (per_gw * load.get(el.get("team"), 0.0) * avail) if per_gw is not None else None
+        rows.append({
+            "element": el["id"], "code": el.get("code"),
+            "web_name": el.get("web_name"),
+            "position": POSITIONS.get(el.get("element_type")),
+            "team": team_names.get(el.get("team")),
+            "availability": avail,
+            "status": el.get("status"), "news": el.get("news") or "",
+            "next3_xp": round(next3, 1) if next3 is not None else None,
+            # ROS is deliberately NOT availability-gated: an injury gates the
+            # next-3 horizon, not the season (status "u" = departed is the
+            # exception and is filtered out of recommendations entirely).
+            "ros_points": round(ros, 1) if ros is not None else None,
+            "tier": projection.get("tier"), "confidence": projection.get("confidence"),
+        })
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Squad evaluation
+# ---------------------------------------------------------------------------
+
+def my_squad(players: pd.DataFrame, element_status: dict, entry_id: int) -> pd.DataFrame:
+    """My current 15, from the latest element-status snapshot."""
+    mine = {row["element"] for row in element_status.get("element_status", [])
+            if row.get("owner") == entry_id}
+    return players[players["element"].isin(mine)].copy()
+
+
+def best_xi(squad: pd.DataFrame, value_col: str = "next3_xp") -> tuple[pd.DataFrame, float]:
+    """Best legal XI (1 GKP + a valid DEF/MID/FWD formation) by value_col."""
+    ranked = {pos: squad[squad["position"] == pos]
+              .sort_values(value_col, ascending=False, na_position="last")
+              for pos in ("GKP", "DEF", "MID", "FWD")}
+    best_total, best_frame = -1.0, None
+    for d, m, f in FORMATIONS:
+        if len(ranked["GKP"]) < 1 or len(ranked["DEF"]) < d \
+                or len(ranked["MID"]) < m or len(ranked["FWD"]) < f:
+            continue
+        xi = pd.concat([ranked["GKP"].head(1), ranked["DEF"].head(d),
+                        ranked["MID"].head(m), ranked["FWD"].head(f)])
+        total = float(xi[value_col].fillna(0).sum())
+        if total > best_total:
+            best_total, best_frame = total, xi
+    if best_frame is None:  # squad too broken for any formation — take best 11
+        best_frame = squad.sort_values(value_col, ascending=False).head(11)
+        best_total = float(best_frame[value_col].fillna(0).sum())
+    return best_frame, round(best_total, 1)
+
+
+# ---------------------------------------------------------------------------
+# Recommendations
+# ---------------------------------------------------------------------------
+
+def recommend(players: pd.DataFrame, squad: pd.DataFrame,
+              top_n: int = 10) -> list[dict[str, Any]]:
+    """Ranked add/drop pairs with the short-vs-long balance made explicit.
+
+    For each free agent, pair with the weakest same-position player in my
+    squad (by ROS). Gains are computed on both horizons; the label encodes
+    the balance so a fixture-run streamer is never confused with a season
+    upgrade.
+    """
+    # Free agents by definition have no owner, so my squad is already excluded.
+    pool = players[players["is_free_agent"] & (players["status"] != "u")]
+    recs: list[dict[str, Any]] = []
+    for _, fa in pool.iterrows():
+        mine = squad[squad["position"] == fa["position"]]
+        if mine.empty or pd.isna(fa["ros_points"]):
+            continue  # cannot recommend a player we cannot value
+        # Weakest same-position player: unprojected players (NaN) rank first —
+        # they are the natural drop candidates; their value counts as 0.
+        drop = mine.sort_values(["ros_points", "next3_xp"], na_position="first").iloc[0]
+
+        def _v(x):
+            return 0.0 if pd.isna(x) else float(x)
+
+        next3_gain = _v(fa["next3_xp"]) - _v(drop["next3_xp"])
+        season_gain = _v(fa["ros_points"]) - _v(drop["ros_points"])
+        if next3_gain <= 0 and season_gain <= 0:
+            continue
+        if next3_gain > 0 and season_gain > 0:
+            label = "upgrade"       # better now AND over the season: add and hold
+        elif next3_gain > 0:
+            label = "stream"        # helps the next 3 GWs only: plan to re-drop
+        else:
+            label = "hold"          # tough fixtures now, better player long-term
+        recs.append({
+            "add": fa["web_name"], "add_team": fa["team"], "position": fa["position"],
+            "drop": drop["web_name"],
+            "next3_gain": round(next3_gain, 1),
+            "season_gain": round(season_gain, 1),
+            "label": label,
+            "add_next3_xp": fa["next3_xp"], "add_ros": fa["ros_points"],
+            "drop_next3_xp": drop["next3_xp"], "drop_ros": drop["ros_points"],
+            "availability": fa["status"], "news": fa["news"],
+            "confidence": fa["confidence"],
+        })
+    # Rank by the better of the two gains so both upgrade and stream value
+    # surface; the label keeps them distinguishable.
+    recs.sort(key=lambda r: -max(r["next3_gain"], r["season_gain"]))
+    return recs[:top_n]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="waiver_plan: roster-aware add/drop recommendations")
+    parser.add_argument("--season", default="2026-27")
+    parser.add_argument("--league", type=int, default=int(os.getenv("LEAGUE_ID", "0") or "0"))
+    parser.add_argument("--entry", type=int, default=int(os.getenv("ENTRY_ID", "0") or "0"))
+    parser.add_argument("--top", type=int, default=10)
+    args = parser.parse_args(argv)
+    if not args.league or not args.entry:
+        parser.error("--league and --entry required (or set LEAGUE_ID / ENTRY_ID)")
+
+    raw_root = _repo_root() / "data/raw" / args.season
+    bootstrap = json.loads((raw_root / "bootstrap/bootstrap-static.json").read_text(encoding="utf-8"))
+    element_status = json.loads(
+        (raw_root / f"league/{args.league}/element-status.json").read_text(encoding="utf-8"))
+    seasons = pd.read_parquet(_repo_root() / "data/derived/ml/player_seasons.parquet")
+
+    players = build_player_table(
+        bootstrap, seasons, _repo_root() / "data/derived/ml/projections_2627.json")
+    free = {row["element"] for row in element_status.get("element_status", [])
+            if row.get("owner") is None}
+    players["is_free_agent"] = players["element"].isin(free)
+
+    squad = my_squad(players, element_status, args.entry)
+    xi, xi_total = best_xi(squad)
+    bench = squad[~squad["element"].isin(xi["element"])]
+
+    def _fmt(x):
+        return "    ?" if pd.isna(x) else f"{x:>5}"
+
+    print(f"\n== MY SQUAD — best XI, next {NEXT_GWS} GWs (xP {xi_total}) ==")
+    for _, p in xi.sort_values(["position", "next3_xp"], ascending=[True, False]).iterrows():
+        flag = f"  [{p['status']}] {p['news']}" if p["status"] != "a" else ""
+        print(f"  {p['position']:<4} {p['web_name']:<20} {p['team']:<4} "
+              f"next3 {_fmt(p['next3_xp'])} | ROS {_fmt(p['ros_points'])}{flag}")
+    print("-- bench --")
+    for _, p in bench.sort_values("next3_xp", ascending=False).iterrows():
+        flag = f"  [{p['status']}] {p['news']}" if p["status"] != "a" else ""
+        print(f"  {p['position']:<4} {p['web_name']:<20} {p['team']:<4} "
+              f"next3 {_fmt(p['next3_xp'])} | ROS {_fmt(p['ros_points'])}{flag}")
+
+    recs = recommend(players, squad, args.top)
+    print(f"\n== WAIVER RECOMMENDATIONS (top {args.top}) ==")
+    print("   label    add                    ->  drop                next3   season")
+    for r in recs:
+        flag = f"  [{r['availability']}] {r['news']}" if r["availability"] != "a" else ""
+        print(f"  {r['label']:<8} {r['add']:<18}({r['position']}) -> {r['drop']:<18} "
+              f"{r['next3_gain']:>+6.1f} {r['season_gain']:>+7.1f}{flag}")
+
+    out = _repo_root() / "data/derived" / args.season / "ml/waiver_plan.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({"xi_next3_xp": xi_total, "recommendations": recs}, indent=1))
+    logger.info("wrote %s", out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend/backend/ml/waiver.py
+++ b/apps/backend/backend/ml/waiver.py
@@ -39,6 +39,8 @@ from typing import Any
 
 import pandas as pd
 
+from backend.ml import jsonutil
+
 logger = logging.getLogger(__name__)
 
 POSITIONS = {1: "GKP", 2: "DEF", 3: "MID", 4: "FWD"}
@@ -295,7 +297,8 @@ def main(argv: list[str] | None = None) -> int:
 
     out = _repo_root() / "data/derived" / args.season / "ml/waiver_plan.json"
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps({"xi_next3_xp": xi_total, "recommendations": recs}, indent=1))
+    out.write_text(jsonutil.dumps_strict(
+        {"xi_next3_xp": xi_total, "recommendations": recs}, indent=1))
     logger.info("wrote %s", out)
     return 0
 

--- a/apps/backend/tests/test_jsonutil.py
+++ b/apps/backend/tests/test_jsonutil.py
@@ -1,0 +1,19 @@
+"""Strict-JSON writer tests: artifacts must never contain bare NaN."""
+import json
+import math
+
+import pytest
+
+from backend.ml import jsonutil
+
+
+def test_nan_and_inf_become_null():
+    text = jsonutil.dumps_strict({"a": float("nan"), "b": [1.0, float("inf")], "c": "ok"})
+    parsed = json.loads(text)  # strict parse must succeed
+    assert parsed == {"a": None, "b": [1.0, None], "c": "ok"}
+    assert "NaN" not in text and "Infinity" not in text
+
+
+def test_finite_values_untouched():
+    assert json.loads(jsonutil.dumps_strict({"x": 1.5})) == {"x": 1.5}
+    assert not math.isnan(json.loads(jsonutil.dumps_strict({"x": 0.0}))["x"])

--- a/apps/backend/tests/test_serve_export.py
+++ b/apps/backend/tests/test_serve_export.py
@@ -1,0 +1,21 @@
+"""Tests for serve_export (player_history.json). No network."""
+import json
+import pandas as pd
+from backend.ml import serve_export as se
+
+
+def test_build_history_orders_seasons_and_nulls(tmp_path):
+    frame = pd.DataFrame([
+        {"code": 7, "season": "2025-26", "team_name": "Arsenal", "minutes": 900,
+         "total_points": 123, "goals_scored": 3, "assists": 1,
+         "expected_goals": None, "expected_assists": 0.5},
+        {"code": 7, "season": "2024-25", "team_name": "Arsenal", "minutes": 3374,
+         "total_points": 344, "goals_scored": 29, "assists": 18,
+         "expected_goals": 24.0, "expected_assists": 12.0},
+    ])
+    history = se.build_history(frame)
+    rows = history["7"]
+    assert [r["season"] for r in rows] == ["2024-25", "2025-26"]  # chronological
+    assert rows[0]["total_points"] == 344.0
+    assert rows[1]["expected_goals"] is None                      # null, not 0
+    assert json.dumps(history)                                    # JSON-serializable

--- a/apps/backend/tests/test_waiver.py
+++ b/apps/backend/tests/test_waiver.py
@@ -1,0 +1,163 @@
+"""Tests for waiver_plan (backend.ml.waiver). No network — fixtures only."""
+
+import json
+
+import pandas as pd
+import pytest
+
+from backend.ml import waiver as wv
+
+TEAMS = [{"id": 1, "name": "Arsenal", "short_name": "ARS"},
+         {"id": 2, "name": "Wolves", "short_name": "WOL"},
+         {"id": 3, "name": "Hull City", "short_name": "HUL"}]  # promoted: no 25/26 rows
+
+SEASONS = pd.DataFrame([
+    {"season": "2025-26", "team_name": "Arsenal", "total_points": 2000},
+    {"season": "2025-26", "team_name": "Wolves", "total_points": 1200},
+])
+
+
+def test_team_strengths_with_promoted_prior():
+    strengths = wv.team_strengths(SEASONS, TEAMS)
+    assert strengths[1] == 2000 and strengths[2] == 1200
+    assert strengths[3] == pytest.approx(0.9 * 1200)  # promoted prior below the floor
+
+
+def test_fixture_multiplier_direction_and_bounds():
+    strengths = {1: 2000.0, 2: 1200.0, 3: 1080.0}
+    weak = wv.fixture_multiplier(1080.0, strengths, is_home=True)
+    strong = wv.fixture_multiplier(2000.0, strengths, is_home=True)
+    assert weak > 1.0 > strong                       # easy fixture boosts, hard reduces
+    for mult in (weak, strong):
+        assert wv.FIXTURE_MULT_MIN <= mult <= wv.FIXTURE_MULT_MAX
+    assert wv.fixture_multiplier(1080.0, strengths, True) > \
+        wv.fixture_multiplier(1080.0, strengths, False)  # home > away
+
+
+def test_next_fixture_load_handles_blank_and_double():
+    bootstrap = {"teams": TEAMS, "fixtures": {
+        "1": [{"team_h": 1, "team_a": 2}],
+        "2": [{"team_h": 2, "team_a": 3}, {"team_h": 3, "team_a": 2}],  # DGW for 2 and 3
+        "3": [],                                                        # blank for all
+    }}
+    strengths = wv.team_strengths(SEASONS, TEAMS)
+    load = wv.next_fixture_load(bootstrap, strengths)
+    assert load[1] > 0                       # one fixture
+    assert load[2] > load[1]                 # three fixtures beats one
+    per_fix_max = wv.FIXTURE_MULT_MAX
+    assert load[2] <= 3 * per_fix_max
+
+
+def test_availability_factor_gates():
+    assert wv.availability_factor({"status": "a"}) == 1.0
+    assert wv.availability_factor({"status": "u"}) == 0.0
+    assert wv.availability_factor({"status": "d", "chance_of_playing_next_round": 50}) == 0.5
+    assert wv.availability_factor({"status": "d"}) == 0.75
+    assert wv.availability_factor({"status": "i"}) == 0.0
+
+
+def _players_fixture(tmp_path):
+    """Small world: my squad has a weak FWD; the market has three FWDs."""
+    bootstrap = {
+        "teams": TEAMS,
+        "fixtures": {"1": [{"team_h": 1, "team_a": 2}], "2": [{"team_h": 2, "team_a": 1}],
+                     "3": [{"team_h": 1, "team_a": 3}]},
+        "elements": [
+            # my players (owned by 42)
+            {"id": 10, "code": 100, "web_name": "MyGK", "element_type": 1, "team": 1, "status": "a"},
+            {"id": 11, "code": 101, "web_name": "MyWeakFWD", "element_type": 4, "team": 2, "status": "a"},
+            # market
+            {"id": 20, "code": 200, "web_name": "SeasonStar", "element_type": 4, "team": 1, "status": "a"},
+            {"id": 21, "code": 201, "web_name": "Streamer", "element_type": 4, "team": 1, "status": "a"},
+            {"id": 22, "code": 202, "web_name": "Departed", "element_type": 4, "team": 1, "status": "u"},
+        ],
+    }
+    projections = [
+        {"code": 100, "projected_points": 120.0},
+        {"code": 101, "projected_points": 80.0},    # my weak FWD: ~2.1/GW
+        {"code": 200, "projected_points": 150.0},   # better now AND all season
+        {"code": 201, "projected_points": 60.0},    # worse season, but... (see test)
+        {"code": 202, "projected_points": 200.0},   # departed — must never appear
+    ]
+    proj_path = tmp_path / "projections.json"
+    proj_path.write_text(json.dumps(projections))
+    players = wv.build_player_table(bootstrap, SEASONS, proj_path)
+    status = {"element_status": [
+        {"element": 10, "owner": 42}, {"element": 11, "owner": 42},
+        {"element": 20, "owner": None}, {"element": 21, "owner": None},
+        {"element": 22, "owner": None},
+    ]}
+    players["is_free_agent"] = players["element"].isin({20, 21, 22})
+    return players, status
+
+
+def test_recommend_labels_upgrade_and_excludes_departed(tmp_path):
+    players, status = _players_fixture(tmp_path)
+    squad = wv.my_squad(players, status, entry_id=42)
+    assert len(squad) == 2
+    recs = wv.recommend(players, squad)
+    names = [r["add"] for r in recs]
+    assert "SeasonStar" in names and "Departed" not in names
+    star = next(r for r in recs if r["add"] == "SeasonStar")
+    assert star["label"] == "upgrade"           # both horizons positive
+    assert star["drop"] == "MyWeakFWD"
+    assert star["season_gain"] == pytest.approx(150.0 - 80.0, abs=0.2)
+
+
+def test_recommend_stream_label_when_only_short_term(tmp_path):
+    players, status = _players_fixture(tmp_path)
+    # Boost Streamer's next3 above MyWeakFWD's by injuring my FWD short-term:
+    # simulate via availability (my FWD 0 chance next rounds -> next3 0)
+    players.loc[players["web_name"] == "MyWeakFWD", "next3_xp"] = 0.5
+    squad = wv.my_squad(players, status, entry_id=42)
+    recs = wv.recommend(players, squad)
+    streamer = next(r for r in recs if r["add"] == "Streamer")
+    assert streamer["next3_gain"] > 0 and streamer["season_gain"] < 0
+    assert streamer["label"] == "stream"
+
+
+def test_best_xi_respects_formation():
+    rows = []
+    for i in range(2):
+        rows.append({"element": i, "position": "GKP", "next3_xp": 10 - i})
+    for i in range(5):
+        rows.append({"element": 10 + i, "position": "DEF", "next3_xp": 20 - i})
+        rows.append({"element": 20 + i, "position": "MID", "next3_xp": 30 - i})
+    for i in range(3):
+        rows.append({"element": 30 + i, "position": "FWD", "next3_xp": 15 - i})
+    squad = pd.DataFrame(rows)
+    xi, total = wv.best_xi(squad)
+    assert len(xi) == 11
+    counts = xi["position"].value_counts()
+    assert counts["GKP"] == 1
+    assert (counts.get("DEF", 0), counts.get("MID", 0), counts.get("FWD", 0)) in \
+        [(d, m, f) for d, m, f in wv.FORMATIONS]
+    assert total > 0
+
+
+def test_unprojected_free_agents_are_never_recommended(tmp_path):
+    """Real-run regression: NaN projections must not produce nan 'hold' recs."""
+    players, status = _players_fixture(tmp_path)
+    players.loc[players["web_name"] == "Streamer", ["ros_points", "next3_xp"]] = float("nan")
+    squad = wv.my_squad(players, status, entry_id=42)
+    recs = wv.recommend(players, squad)
+    assert all(r["add"] != "Streamer" for r in recs)
+    assert all(not pd.isna(r["season_gain"]) for r in recs)
+
+
+def test_injury_gates_next3_but_not_season_value(tmp_path):
+    """Real-run regression: an injured player's ROS survives; next3 goes to 0."""
+    bootstrap = {
+        "teams": TEAMS,
+        "fixtures": {"1": [{"team_h": 1, "team_a": 2}]},
+        "elements": [{"id": 50, "code": 500, "web_name": "InjuredStar",
+                      "element_type": 2, "team": 1, "status": "i",
+                      "chance_of_playing_next_round": 0,
+                      "news": "Groin injury"}],
+    }
+    proj = tmp_path / "p.json"
+    proj.write_text(json.dumps([{"code": 500, "projected_points": 140.0}]))
+    table = wv.build_player_table(bootstrap, SEASONS, proj)
+    row = table.iloc[0]
+    assert row["next3_xp"] == 0.0          # gated now
+    assert row["ros_points"] == 140.0      # season value intact

--- a/apps/mcp-server/fpl-server/draft_tools.go
+++ b/apps/mcp-server/fpl-server/draft_tools.go
@@ -1,0 +1,247 @@
+package main
+
+// Decision-layer tools (the serving layer for the ML pipeline).
+//
+// These tools serve the artifacts the Python pipeline writes — they do no
+// modeling themselves, keeping the repo's boundary intact (Python computes,
+// Go serves local JSON):
+//
+//	draft_board  <- data/derived/ml/projections_2627.json
+//	player_card  <- projections + data/derived/ml/player_history.json
+//	             + data/raw/<season>/bootstrap/bootstrap-static.json (live news)
+//	waiver_plan  <- data/derived/<season>/ml/waiver_plan.json
+//	drop_radar   <- data/derived/<season>/ml/ownership_events.json
+//
+// Season-aware paths use ServerConfig.DefaultSeason unless the call passes an
+// explicit season. The legacy flat roots remain the 2025-26 archive.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// Shared plumbing
+// ---------------------------------------------------------------------------
+
+// projectionRow mirrors one entry of projections_2627.json (written by
+// backend.ml.projection --project).
+type projectionRow struct {
+	Code            int     `json:"code"`
+	WebName         string  `json:"web_name"`
+	Position        string  `json:"position"`
+	ProjectedPoints float64 `json:"projected_points"`
+	Tier            int     `json:"tier"`
+	Vor             float64 `json:"vor"`
+	Confidence      string  `json:"confidence"`
+	RiskFlags       string  `json:"risk_flags"`
+	PositionRank    int     `json:"position_rank"`
+	Drivers         string  `json:"drivers"`
+}
+
+func (cfg ServerConfig) season(override string) string {
+	if override != "" {
+		return override
+	}
+	return cfg.DefaultSeason
+}
+
+func readJSONFile(path string, v any) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w (run the pipeline that writes it first)", path, err)
+	}
+	return json.Unmarshal(raw, v)
+}
+
+func loadProjections(cfg ServerConfig) ([]projectionRow, error) {
+	var rows []projectionRow
+	err := readJSONFile(filepath.Join(cfg.DerivedRoot, "ml/projections_2627.json"), &rows)
+	return rows, err
+}
+
+// ---------------------------------------------------------------------------
+// draft_board
+// ---------------------------------------------------------------------------
+
+type DraftBoardArgs struct {
+	Position string `json:"position,omitempty" jsonschema:"Filter to one position: GKP DEF MID or FWD (empty = all)"`
+	Top      int    `json:"top,omitempty" jsonschema:"Players per position to return (default 20)"`
+}
+
+func draftBoardHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest, DraftBoardArgs) (*mcp.CallToolResult, any, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, args DraftBoardArgs) (*mcp.CallToolResult, any, error) {
+		rows, err := loadProjections(cfg)
+		if err != nil {
+			return toolError(err), nil, nil
+		}
+		top := args.Top
+		if top <= 0 {
+			top = 20
+		}
+		position := strings.ToUpper(strings.TrimSpace(args.Position))
+		out := make([]projectionRow, 0, top*4)
+		for _, row := range rows {
+			if position != "" && row.Position != position {
+				continue
+			}
+			if row.PositionRank <= top {
+				out = append(out, row)
+			}
+		}
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].Position != out[j].Position {
+				return out[i].Position < out[j].Position
+			}
+			return out[i].PositionRank < out[j].PositionRank
+		})
+		return toolMarshal(map[string]any{
+			"note":  "projected_points = next-season projection (see PROJECTION_MODEL_SPEC); vor = value over replacement at 12-team starter depth",
+			"board": out,
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// player_card
+// ---------------------------------------------------------------------------
+
+type PlayerCardArgs struct {
+	Name   string `json:"name" jsonschema:"Player web name to look up (case-insensitive, substring ok; required)"`
+	Season string `json:"season,omitempty" jsonschema:"Season for live availability news (default: server default season)"`
+}
+
+// historyRow mirrors one season entry of player_history.json (written by
+// backend.ml.serve_export).
+type historyRow struct {
+	Season      string   `json:"season"`
+	TeamName    string   `json:"team_name"`
+	Minutes     *float64 `json:"minutes"`
+	TotalPoints *float64 `json:"total_points"`
+	Goals       *float64 `json:"goals_scored"`
+	Assists     *float64 `json:"assists"`
+	Xg          *float64 `json:"expected_goals"`
+	Xa          *float64 `json:"expected_assists"`
+}
+
+func playerCardHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest, PlayerCardArgs) (*mcp.CallToolResult, any, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, args PlayerCardArgs) (*mcp.CallToolResult, any, error) {
+		needle := strings.ToLower(strings.TrimSpace(args.Name))
+		if needle == "" {
+			return toolError(fmt.Errorf("name is required")), nil, nil
+		}
+		rows, err := loadProjections(cfg)
+		if err != nil {
+			return toolError(err), nil, nil
+		}
+		var match *projectionRow
+		for i := range rows {
+			if strings.Contains(strings.ToLower(rows[i].WebName), needle) {
+				if match != nil {
+					return toolError(fmt.Errorf("ambiguous name %q (matches %s and %s) — be more specific",
+						args.Name, match.WebName, rows[i].WebName)), nil, nil
+				}
+				match = &rows[i]
+			}
+		}
+		if match == nil {
+			return toolError(fmt.Errorf("no projected player matches %q (promoted/new players have no projection)", args.Name)), nil, nil
+		}
+
+		// Multi-season history — the reversion safeguard: the projection must
+		// never be shown without the player's history next to it.
+		history := map[string][]historyRow{}
+		historyPath := filepath.Join(cfg.DerivedRoot, "ml/player_history.json")
+		if err := readJSONFile(historyPath, &history); err != nil {
+			return toolError(err), nil, nil
+		}
+		seasons := history[fmt.Sprintf("%d", match.Code)]
+
+		// Live availability from the season bootstrap (best effort).
+		news := map[string]any{}
+		bootstrapPath := filepath.Join(cfg.RawRoot, cfg.season(args.Season), "bootstrap/bootstrap-static.json")
+		var bootstrap struct {
+			Elements []struct {
+				Code                     int    `json:"code"`
+				Status                   string `json:"status"`
+				News                     string `json:"news"`
+				ChanceOfPlayingNextRound *int   `json:"chance_of_playing_next_round"`
+			} `json:"elements"`
+		}
+		if err := readJSONFile(bootstrapPath, &bootstrap); err == nil {
+			for _, el := range bootstrap.Elements {
+				if el.Code == match.Code {
+					news = map[string]any{
+						"status": el.Status, "news": el.News,
+						"chance_of_playing_next_round": el.ChanceOfPlayingNextRound,
+					}
+					break
+				}
+			}
+		}
+
+		return toolMarshal(map[string]any{
+			"projection":     match,
+			"season_history": seasons,
+			"availability":   news,
+			"note":           "Judge the projection against season_history: a one-season dip (injury) or spike may revert — the model has no multi-year reversion (see ISSUES.md).",
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waiver_plan
+// ---------------------------------------------------------------------------
+
+type WaiverPlanArgs struct {
+	Season string `json:"season,omitempty" jsonschema:"Season (default: server default season)"`
+}
+
+func waiverPlanHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest, WaiverPlanArgs) (*mcp.CallToolResult, any, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, args WaiverPlanArgs) (*mcp.CallToolResult, any, error) {
+		path := filepath.Join(cfg.DerivedRoot, cfg.season(args.Season), "ml/waiver_plan.json")
+		var plan map[string]any
+		if err := readJSONFile(path, &plan); err != nil {
+			return toolError(err), nil, nil
+		}
+		plan["note"] = "labels: upgrade = better now and all season; stream = next-3-GW help only (plan to re-drop); hold = tough fixtures now but better rest-of-season. Regenerate with: python -m backend.ml.waiver"
+		return toolMarshal(plan)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// drop_radar
+// ---------------------------------------------------------------------------
+
+type DropRadarArgs struct {
+	Season string `json:"season,omitempty" jsonschema:"Season (default: server default season)"`
+	Limit  int    `json:"limit,omitempty" jsonschema:"Most recent events to return (default 25)"`
+}
+
+func dropRadarHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest, DropRadarArgs) (*mcp.CallToolResult, any, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, args DropRadarArgs) (*mcp.CallToolResult, any, error) {
+		path := filepath.Join(cfg.DerivedRoot, cfg.season(args.Season), "ml/ownership_events.json")
+		var events []map[string]any
+		if err := readJSONFile(path, &events); err != nil {
+			return toolError(err), nil, nil
+		}
+		limit := args.Limit
+		if limit <= 0 {
+			limit = 25
+		}
+		if len(events) > limit {
+			events = events[len(events)-limit:]
+		}
+		return toolMarshal(map[string]any{
+			"note":   "ownership changes between element-status snapshots (drop = released to free agency). Regenerate with the fetcher + python -m backend.ml.ownership",
+			"events": events,
+		})
+	}
+}

--- a/apps/mcp-server/fpl-server/draft_tools_test.go
+++ b/apps/mcp-server/fpl-server/draft_tools_test.go
@@ -1,0 +1,161 @@
+package main
+
+// Tests for the decision-layer tools. Fixtures in t.TempDir() per repo rules —
+// no live calls, no dependence on real data/ contents.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func writeFixture(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fixtureConfig(t *testing.T) ServerConfig {
+	t.Helper()
+	root := t.TempDir()
+	cfg := ServerConfig{
+		RawRoot:       filepath.Join(root, "raw"),
+		DerivedRoot:   filepath.Join(root, "derived"),
+		DefaultSeason: "2026-27",
+	}
+	writeFixture(t, filepath.Join(cfg.DerivedRoot, "ml/projections_2627.json"), []map[string]any{
+		{"code": 1, "web_name": "Alpha", "position": "FWD", "projected_points": 200.0,
+			"tier": 1, "vor": 90.0, "confidence": "high", "risk_flags": "", "position_rank": 1,
+			"drivers": "pts90+"},
+		{"code": 2, "web_name": "Beta", "position": "FWD", "projected_points": 150.0,
+			"tier": 2, "vor": 40.0, "confidence": "high", "risk_flags": "", "position_rank": 2,
+			"drivers": "xg90+"},
+		{"code": 3, "web_name": "Gamma", "position": "MID", "projected_points": 180.0,
+			"tier": 1, "vor": 80.0, "confidence": "medium", "risk_flags": "low_minutes",
+			"position_rank": 1, "drivers": "ict_index+"},
+	})
+	return cfg
+}
+
+func resultText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	if res == nil || len(res.Content) == 0 {
+		t.Fatal("empty tool result")
+	}
+	text, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("unexpected content type %T", res.Content[0])
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %s", text.Text)
+	}
+	return text.Text
+}
+
+func TestDraftBoardFiltersPositionAndTop(t *testing.T) {
+	cfg := fixtureConfig(t)
+	res, _, err := draftBoardHandler(cfg)(context.Background(), nil, DraftBoardArgs{Position: "fwd", Top: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "Alpha") || strings.Contains(text, "Beta") {
+		t.Fatalf("expected only FWD rank 1 (Alpha), got: %s", text)
+	}
+	if strings.Contains(text, "Gamma") {
+		t.Fatal("position filter leaked a MID row")
+	}
+}
+
+func TestPlayerCardMergesHistoryAndFlagsAmbiguity(t *testing.T) {
+	cfg := fixtureConfig(t)
+	writeFixture(t, filepath.Join(cfg.DerivedRoot, "ml/player_history.json"), map[string]any{
+		"1": []map[string]any{
+			{"season": "2024-25", "team_name": "Arsenal", "total_points": 344.0},
+			{"season": "2025-26", "team_name": "Arsenal", "total_points": 123.0},
+		},
+	})
+	writeFixture(t, filepath.Join(cfg.RawRoot, "2026-27/bootstrap/bootstrap-static.json"), map[string]any{
+		"elements": []map[string]any{
+			{"code": 1, "status": "d", "news": "Knock", "chance_of_playing_next_round": 75},
+		},
+	})
+
+	res, _, err := playerCardHandler(cfg)(context.Background(), nil, PlayerCardArgs{Name: "alph"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := resultText(t, res)
+	for _, want := range []string{"344", "123", "Knock", "season_history"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("card missing %q: %s", want, text)
+		}
+	}
+
+	// Ambiguous substring must error, not guess.
+	res, _, _ = playerCardHandler(cfg)(context.Background(), nil, PlayerCardArgs{Name: "a"})
+	if res == nil || !res.IsError {
+		t.Fatal("expected ambiguity error for name 'a'")
+	}
+}
+
+func TestWaiverPlanServesSeasonArtifact(t *testing.T) {
+	cfg := fixtureConfig(t)
+	writeFixture(t, filepath.Join(cfg.DerivedRoot, "2026-27/ml/waiver_plan.json"), map[string]any{
+		"xi_next3_xp": 49.3,
+		"recommendations": []map[string]any{
+			{"add": "Dubravka", "drop": "BackupGK", "label": "upgrade",
+				"next3_gain": 7.5, "season_gain": 96.0},
+		},
+	})
+	res, _, err := waiverPlanHandler(cfg)(context.Background(), nil, WaiverPlanArgs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "Dubravka") || !strings.Contains(text, "49.3") {
+		t.Fatalf("waiver plan not served: %s", text)
+	}
+}
+
+func TestDropRadarReturnsMostRecentEvents(t *testing.T) {
+	cfg := fixtureConfig(t)
+	events := []map[string]any{
+		{"ts": "t1", "kind": "add", "web_name": "Old"},
+		{"ts": "t2", "kind": "drop", "web_name": "Recent"},
+	}
+	writeFixture(t, filepath.Join(cfg.DerivedRoot, "2026-27/ml/ownership_events.json"), events)
+	res, _, err := dropRadarHandler(cfg)(context.Background(), nil, DropRadarArgs{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "Recent") || strings.Contains(text, "Old") {
+		t.Fatalf("expected only the most recent event: %s", text)
+	}
+}
+
+func TestToolsErrorCleanlyWhenArtifactsMissing(t *testing.T) {
+	cfg := ServerConfig{RawRoot: t.TempDir(), DerivedRoot: t.TempDir(), DefaultSeason: "2026-27"}
+	res, _, _ := draftBoardHandler(cfg)(context.Background(), nil, DraftBoardArgs{})
+	if res == nil || !res.IsError {
+		t.Fatal("draft_board should error when projections are missing")
+	}
+	res, _, _ = waiverPlanHandler(cfg)(context.Background(), nil, WaiverPlanArgs{})
+	if res == nil || !res.IsError {
+		t.Fatal("waiver_plan should error when the artifact is missing")
+	}
+}

--- a/apps/mcp-server/fpl-server/main.go
+++ b/apps/mcp-server/fpl-server/main.go
@@ -24,6 +24,7 @@ type ServerConfig struct {
 	DerivedRoot    string
 	WriteDerived   bool
 	ComputeMissing bool
+	DefaultSeason  string // season used by the decision tools when a call omits one
 }
 
 type LeagueGWArgs struct {
@@ -77,6 +78,7 @@ func main() {
 		mcpPath        = flag.String("path", "/mcp", "HTTP path for MCP endpoint")
 		rawRoot        = flag.String("raw-root", "data/raw", "root directory for raw JSON")
 		derivedRoot    = flag.String("derived-root", "data/derived", "root directory for derived JSON")
+		defaultSeason  = flag.String("default-season", "2026-27", "season the decision tools (draft_board/player_card/waiver_plan/drop_radar) read when a call omits one")
 		writeDerived   = flag.Bool("write-derived", true, "write computed summaries to derived root")
 		computeMissing = flag.Bool("compute-missing", true, "compute summaries if missing")
 		requireAuth    = flag.Bool("require-auth", true, "require API key auth via FPL_MCP_API_KEY")
@@ -87,6 +89,7 @@ func main() {
 	cfg := ServerConfig{
 		RawRoot:        *rawRoot,
 		DerivedRoot:    *derivedRoot,
+		DefaultSeason:  *defaultSeason,
 		WriteDerived:   *writeDerived,
 		ComputeMissing: *computeMissing,
 	}
@@ -439,6 +442,26 @@ func main() {
 		Name:        "game_status",
 		Description: "Current game state: GW progress, deadlines (waivers/trades/lineup lock), fixture status, points finality",
 	}, gameStatusHandler(cfg))
+
+	addTool(server, &registry, &mcp.Tool{
+		Name:        "draft_board",
+		Description: "The 2026-27 draft board: players ranked per position with projected points, tiers, VOR (12-team), confidence, risk flags, and drivers",
+	}, draftBoardHandler(cfg))
+
+	addTool(server, &registry, &mcp.Tool{
+		Name:        "player_card",
+		Description: "Everything about one player: projection with drivers, multi-season history (judge dips/spikes), and live availability news",
+	}, playerCardHandler(cfg))
+
+	addTool(server, &registry, &mcp.Tool{
+		Name:        "waiver_plan",
+		Description: "Roster-aware add/drop recommendations: best-XI evaluation plus adds paired with drops, each labeled upgrade/stream/hold with next-3-GW and season gains",
+	}, waiverPlanHandler(cfg))
+
+	addTool(server, &registry, &mcp.Tool{
+		Name:        "drop_radar",
+		Description: "Recent league ownership changes (who got dropped/added/traded) from element-status snapshot diffs",
+	}, dropRadarHandler(cfg))
 
 	addTool(server, &registry, &mcp.Tool{
 		Name:        "epl_fixtures",

--- a/docs/CLAUDE_DESKTOP.md
+++ b/docs/CLAUDE_DESKTOP.md
@@ -1,0 +1,60 @@
+# Connecting Claude Desktop (or Claude Code) to the FPL co-pilot
+
+The Go MCP server serves 30 tools over Streamable HTTP at `/mcp`, including the
+decision layer: `draft_board`, `player_card`, `waiver_plan`, `drop_radar`.
+Claude (on a Max plan) is the client — there is no in-app LLM.
+
+## 1. Start the server
+
+```bash
+cd apps/mcp-server
+FPL_MCP_API_KEY=<your-random-secret> go run ./fpl-server \
+  --raw-root ../../data/raw --derived-root ../../data/derived \
+  --default-season 2026-27
+```
+
+Path convention: the flat roots are the 2025-26 archive; the decision tools
+read season-nested paths (`data/raw/<season>/`, `data/derived/<season>/`) using
+`--default-season` unless a call passes `season` explicitly.
+
+## 2. Connect a client
+
+**Claude Code (simplest):**
+
+```bash
+claude mcp add fpl --transport http http://localhost:8080/mcp \
+  --header "X-API-Key: <your-random-secret>"
+```
+
+**Claude Desktop** (custom connector → local servers need a stdio bridge):
+
+```json
+{
+  "mcpServers": {
+    "fpl": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://localhost:8080/mcp",
+               "--header", "X-API-Key:<your-random-secret>"]
+    }
+  }
+}
+```
+
+## 3. Keep the artifacts fresh (the weekly loop)
+
+The decision tools serve files the pipeline writes. Before waivers each week:
+
+```bash
+# fetch: game state, league, transactions + element-status snapshot
+cd apps/mcp-server && go run ./cmd/dev --league <LEAGUE_ID> --season 2026-27 \
+  --raw-root ../../data/raw --derived-root ../../data/derived --fast --refresh-now
+
+# derive: ownership events + waiver plan (+ projections/history after ingests)
+cd ../backend
+python -m backend.ml.ownership --league <LEAGUE_ID>
+python -m backend.ml.waiver    --league <LEAGUE_ID> --entry <ENTRY_ID>
+```
+
+Then ask Claude things like *"run my waiver plan — who do I add and drop, and
+which of those are streams vs season upgrades?"* or *"player card for
+Maddison — should I worry?"*.


### PR DESCRIPTION
## What changed
**waiver_plan (backend.ml.waiver):** roster-aware add/drop CLI — best legal XI over the next 3 GWs, free-agent recs each paired with a drop, and the short-vs-long balance explicit: `next3_gain` AND `season_gain` per rec with `upgrade`/`stream`/`hold` labels. Per-GW baseline from the season projection (swappable for the match xP model later); fixture multipliers from 25/26 team strengths with a promoted-team prior; availability gates the next-3 horizon only (ROS survives injuries). 9 tests incl. two real-run regressions.

**Serving layer (Go, 30 tools total):** `draft_board`, `player_card` (projection + multi-season history + live news side-by-side — the reversion safeguard), `waiver_plan`, `drop_radar` — thin readers over the pipeline's JSON artifacts, per the repo's Python-computes/Go-serves boundary. New `--default-season` flag; 5 Go tests (first for the serving surface). `serve_export` writes player_history.json; `jsonutil.dumps_strict` fixes NaN-poisoned artifacts (invalid strict JSON that Go rejected) — both writers routed through it with regression tests.

**docs/CLAUDE_DESKTOP.md:** connector setup (Claude Code / Desktop via mcp-remote) + the weekly artifact-refresh loop.

## Why
The evaluation flagged the project's systemic gap: 'shipping brains without a mouth'. This attaches the mouth before GW1 — every model artifact is now askable from Claude Desktop/Code.

## How to test
`pytest` (291 passed) · `go test ./...` (green incl. 5 new tool tests) · verified end-to-end over real MCP initialize→tools/call against live artifacts.

## Commands run
pytest, ruff (clean), gofmt/go vet/go test (clean), live MCP smoke of all four tools, artifact strict-JSON validation.

## Risks / Edge cases
Tools error cleanly (IsError) when artifacts are missing, pointing at the pipeline command that writes them. Ambiguous player_card names error rather than guess. Promoted/new players have no projection by design (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)