### PR TITLE
fix: never double-ingest 2025-26 (vaastav + stray local bootstrap)

### DIFF
--- a/apps/backend/backend/ml/history.py
+++ b/apps/backend/backend/ml/history.py
@@ -263,7 +263,13 @@ def ingest(
         season_rows = load_vaastav_season(season, scratch_dir, base_url, session)
         logger.info("season %s: %d players (vaastav)", season, len(season_rows))
         rows.extend(season_rows)
-    if local_bootstrap_path and Path(local_bootstrap_path).exists():
+    if LOCAL_SEASON in historical_seasons:
+        # Already ingested from vaastav — loading the local archive too would
+        # duplicate every (code, season) row. Fresh machines pass 2025-26 in
+        # --seasons precisely because they lack the local archive; ignore any
+        # stray local file so both sources are never mixed.
+        logger.info("season %s ingested from vaastav; skipping local bootstrap", LOCAL_SEASON)
+    elif local_bootstrap_path and Path(local_bootstrap_path).exists():
         local_rows = load_local_season(Path(local_bootstrap_path))
         logger.info("season %s: %d players (local)", LOCAL_SEASON, len(local_rows))
         rows.extend(local_rows)

--- a/apps/backend/tests/test_history.py
+++ b/apps/backend/tests/test_history.py
@@ -106,3 +106,36 @@ def test_local_bootstrap_maps_team_name_and_nulls_now_cost():
     assert frame.loc[0, "team_name"] == "Man City"
     assert pd.isna(frame.loc[0, "now_cost"])
     assert frame.loc[0, "expected_goals"] == 25.5
+
+
+def test_local_season_in_seasons_list_never_double_ingests(tmp_path, monkeypatch):
+    """Regression: passing 2025-26 in --seasons (the fresh-machine path) while
+    a stray local bootstrap exists must use vaastav ONLY, not both."""
+    import json
+
+    def fake_vaastav(season, scratch_dir, base_url, session):
+        return history.parse_local_bootstrap({
+            "elements": [{"code": 100, "id": 1, "web_name": "V", "element_type": 3,
+                          "team": 1, "minutes": 900, "total_points": 50}],
+            "teams": [{"id": 1, "name": "Arsenal", "short_name": "ARS"}],
+        }, season)
+
+    monkeypatch.setattr(history, "load_vaastav_season", fake_vaastav)
+    local = tmp_path / "bootstrap-static.json"
+    local.write_text(json.dumps({
+        "elements": [{"code": 100, "id": 9, "web_name": "L", "element_type": 3,
+                      "team": 1, "minutes": 1, "total_points": 1}],
+        "teams": [{"id": 1, "name": "Arsenal", "short_name": "ARS"}],
+    }))
+
+    frame = history.ingest(
+        historical_seasons=[history.LOCAL_SEASON],
+        local_bootstrap_path=local, scratch_dir=tmp_path)
+    assert len(frame) == 1
+    assert frame.loc[0, "web_name"] == "V"          # vaastav row won; local skipped
+
+    # Control: local season NOT requested from vaastav -> local file is used.
+    frame = history.ingest(
+        historical_seasons=[], local_bootstrap_path=local, scratch_dir=tmp_path)
+    assert len(frame) == 1
+    assert frame.loc[0, "web_name"] == "L"


### PR DESCRIPTION
## What changed
When `2025-26` is in the requested vaastav season list, `ingest()` now skips the local flat-root bootstrap instead of loading the season twice. Local file still wins when 2025-26 is not requested from vaastav (the archive-machine path).

## Why
Real failure on a fresh machine: the fresh-clone bootstrap passes `--seasons ... 2025-26` (no local archive), but a stray unseasoned fetch had left a bootstrap at the flat path — both sources loaded and the (code, season) integrity check refused with 841 duplicate rows. Worse, the stray file was current-season data mislabeled as 2025-26, so silently preferring it would have poisoned projections; the explicit vaastav request must win.

## How to test
`cd apps/backend && uv run pytest tests/test_history.py` — new regression test covers both paths (vaastav-requested + stray local → single ingest from vaastav; local-only path unchanged).

## Commands run
uv run pytest (301 passed) · uv run ruff check (clean)

## Risks / Edge cases
None beyond the guarded path; archive machines (local 25/26, default seasons list) behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)