### PR TITLE
fix: my_week never starts zero-availability players over fit ones

### DIFF
--- a/apps/backend/backend/ml/myweek.py
+++ b/apps/backend/backend/ml/myweek.py
@@ -64,11 +64,35 @@ def player_warnings(row: pd.Series) -> list[str]:
     return warnings
 
 
+def xi_selection_value(row: pd.Series) -> float:
+    """Ordering for start/sit decisions — stricter than raw gw_xp.
+
+    Raw gw_xp cannot rank the edge cases: an injured projected player scores
+    0.0 while a fit unprojected player scores NaN, so the injured one wins
+    ties (the Madjo/Maddison GW1 bug). The rule made explicit:
+
+      projected + available  ->  their gw_xp (as before)
+      unprojected + available -> 0.0  (unknown, but CAN play)
+      availability 0          -> -1.0 (cannot play — never start over anyone
+                                       who can, projected or not)
+    """
+    if row["availability"] == 0:
+        return -1.0
+    if pd.isna(row["gw_xp"]):
+        return 0.0
+    return float(row["gw_xp"])
+
+
 def build_my_week(players: pd.DataFrame, element_status: dict,
                   entry_id: int) -> dict[str, Any]:
     """XI + bench + attention list for my squad, scored on gw_xp."""
     squad = wv.my_squad(players, element_status, entry_id)
-    xi, xi_total = wv.best_xi(squad, value_col="gw_xp")
+    squad["xi_value"] = squad.apply(xi_selection_value, axis=1)
+    xi, _ = wv.best_xi(squad, value_col="xi_value")
+    # Report real expected points, not the selection ordering (which carries
+    # a -1 penalty for unavailable players).
+    xi_total = round(float(pd.to_numeric(xi["gw_xp"], errors="coerce")
+                           .fillna(0).clip(lower=0).sum()), 1)
     bench = squad[~squad["element"].isin(xi["element"])]
 
     def rows(frame: pd.DataFrame) -> list[dict[str, Any]]:

--- a/apps/backend/tests/test_myweek.py
+++ b/apps/backend/tests/test_myweek.py
@@ -77,6 +77,70 @@ def test_build_my_week_xi_bench_and_attention(tmp_path):
     assert "P114" not in xi_names                     # unknown never auto-started
 
 
+def test_xi_selection_value_ordering():
+    """projected+fit > unprojected+fit > unavailable, regardless of gw_xp."""
+    projected_fit = pd.Series({"availability": 1.0, "gw_xp": 2.5})
+    unknown_fit = pd.Series({"availability": 1.0, "gw_xp": float("nan")})
+    injured_projected = pd.Series({"availability": 0.0, "gw_xp": 0.0})
+    injured_unknown = pd.Series({"availability": 0.0, "gw_xp": float("nan")})
+
+    assert mw.xi_selection_value(projected_fit) == 2.5
+    assert mw.xi_selection_value(unknown_fit) == 0.0
+    assert mw.xi_selection_value(injured_projected) == -1.0
+    assert mw.xi_selection_value(injured_unknown) == -1.0
+
+
+def test_injured_players_never_start_over_fit_ones(tmp_path):
+    """The Madjo/Maddison GW1 regression: with fit alternatives on the bench,
+    zero-chance players must never occupy an XI slot — and a fit unprojected
+    player must outrank an injured projected one."""
+    elements, projections = [], []
+    code = 100
+    # 2 GKP, 4 DEF (all fit/projected — only nine fit projected outfielders in
+    # total, so the tenth XI slot MUST come from the unknown or the injured),
+    # then crafted MID and FWD rooms.
+    for pos_type, count in ((1, 2), (2, 4)):
+        for _ in range(count):
+            elements.append({"id": code, "code": code, "web_name": f"P{code}",
+                             "element_type": pos_type, "team": 1, "status": "a"})
+            projections.append({"code": code, "projected_points": 150.0 - code % 100})
+            code += 1
+    # MIDs: three projected fit, one projected but OUT, one unprojected fit.
+    for name, status, projected in (
+            ("MidA", "a", True), ("MidB", "a", True), ("MidC", "a", True),
+            ("MidInjured", "i", True), ("MidMystery", "a", False)):
+        el = {"id": code, "code": code, "web_name": name, "element_type": 3,
+              "team": 1, "status": status}
+        if status == "i":
+            el["chance_of_playing_next_round"] = 0
+        elements.append(el)
+        if projected:
+            projections.append({"code": code, "projected_points": 120.0})
+        code += 1
+    # FWDs: two projected fit, one unprojected AND out (the Madjo case).
+    for name, status, projected in (
+            ("FwdA", "a", True), ("FwdB", "a", True), ("FwdMadjo", "i", False)):
+        el = {"id": code, "code": code, "web_name": name, "element_type": 4,
+              "team": 1, "status": status}
+        if status == "i":
+            el["chance_of_playing_next_round"] = 0
+        elements.append(el)
+        if projected:
+            projections.append({"code": code, "projected_points": 110.0})
+        code += 1
+
+    bootstrap, players = _world(tmp_path, elements, projections)
+    status = {"element_status": [{"element": e["id"], "owner": 42} for e in elements]}
+    week = mw.build_my_week(players, status, entry_id=42)
+
+    xi_names = {p["web_name"] for p in week["xi"]}
+    assert "FwdMadjo" not in xi_names          # zero-chance never starts
+    assert "MidInjured" not in xi_names        # even projected, out is out
+    assert "MidMystery" in xi_names            # fit unknown beats injured anybody
+    assert len(week["xi"]) == 11
+    assert week["xi_gw_xp"] > 0                # total is real xP, no -1 leakage
+
+
 def test_blank_gameweek_flags_players(tmp_path):
     elements = [{"id": 1, "code": 10, "web_name": "Blanked", "element_type": 3,
                  "team": 2, "status": "a"}]


### PR DESCRIPTION
## What changed
XI selection in `my_week` now uses an explicit ordering (`xi_selection_value`): projected+fit players by their gw_xp, unprojected-but-fit at 0.0, and any player with availability 0 at −1.0 — so a player who cannot play never occupies an XI slot while anyone who can play exists. Reported `xi_gw_xp` sums real expected points of the chosen XI (selection penalties never leak into the total).

## Why
Live GW1 bug found via player_card review: raw gw_xp cannot rank the edge cases — an injured projected player scores 0.0 while a fit unprojected player scores NaN, so ties broke toward starting the injured player (an injured, unprojected FWD held an XI slot while a fit, historically strong MID sat on the bench).

## How to test
`cd apps/backend && uv run pytest tests/test_myweek.py` — new ordering unit test + full regression reproducing the GW1 squad shape. Real-data rerun now selects the correct 4-4-2.

## Commands run
uv run pytest (303 passed) · uv run ruff check (clean)

## Risks / Edge cases
If every player at a required position has availability 0, the formation loop still fields a legal XI (least-bad); warnings/attention flags unchanged. waiver_plan's next-3 XI is unchanged by design (its horizon extends past current injuries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)