### PR TITLE
feat: TUI shows manager names under team names

### DIFF
--- a/apps/mcp-server/cmd/tui/model.go
+++ b/apps/mcp-server/cmd/tui/model.go
@@ -29,6 +29,7 @@ type playerRow struct {
 
 type side struct {
 	Name    string
+	Manager string
 	EntryID int
 	Total   int
 	Bench   int
@@ -93,6 +94,8 @@ func load(dir string, league, entry, gwArg int) (snapshot, int, error) {
 			ID        int    `json:"id"`
 			EntryID   int    `json:"entry_id"`
 			EntryName string `json:"entry_name"`
+			FirstName string `json:"player_first_name"`
+			LastName  string `json:"player_last_name"`
 		} `json:"league_entries"`
 		Matches []struct {
 			Event        int `json:"event"`
@@ -105,9 +108,11 @@ func load(dir string, league, entry, gwArg int) (snapshot, int, error) {
 	}
 	entryByLE := map[int]int{}
 	nameByEntry := map[int]string{}
+	managerByEntry := map[int]string{}
 	for _, e := range details.LeagueEntries {
 		entryByLE[e.ID] = e.EntryID
 		nameByEntry[e.EntryID] = e.EntryName
+		managerByEntry[e.EntryID] = strings.TrimSpace(e.FirstName + " " + e.LastName)
 	}
 
 	var live struct {
@@ -146,7 +151,7 @@ func load(dir string, league, entry, gwArg int) (snapshot, int, error) {
 	}
 
 	buildSide := func(entryID int) side {
-		s := side{Name: nameByEntry[entryID], EntryID: entryID}
+		s := side{Name: nameByEntry[entryID], Manager: managerByEntry[entryID], EntryID: entryID}
 		var picks struct {
 			Picks []struct {
 				Element  int `json:"element"`
@@ -264,8 +269,11 @@ func renderSide(s side, mine bool) string {
 	if mine {
 		name = mineStyle.Render(name + " (you)")
 	}
-	b.WriteString(fmt.Sprintf("%s\n%s  %s\n\n",
-		name,
+	b.WriteString(name + "\n")
+	if s.Manager != "" {
+		b.WriteString(dimStyle.Render(s.Manager) + "\n")
+	}
+	b.WriteString(fmt.Sprintf("%s  %s\n\n",
 		scoreStyle.Render(fmt.Sprintf("%3d pts", s.Total)),
 		dimStyle.Render(fmt.Sprintf("%d/11 played · bench %d", s.Played, s.Bench))))
 	for _, p := range s.Players {

--- a/apps/mcp-server/cmd/tui/model_test.go
+++ b/apps/mcp-server/cmd/tui/model_test.go
@@ -27,7 +27,7 @@ func fixtureDir(t *testing.T) string {
 	write(t, filepath.Join(dir, "game/game.json"), map[string]any{"current_event": 1})
 	write(t, filepath.Join(dir, "league/5/details.json"), map[string]any{
 		"league_entries": []map[string]any{
-			{"id": 71, "entry_id": 501, "entry_name": "Harbor FC"},
+			{"id": 71, "entry_id": 501, "entry_name": "Harbor FC", "player_first_name": "Ava", "player_last_name": "Stone"},
 			{"id": 72, "entry_id": 502, "entry_name": "Dock United"},
 			{"id": 73, "entry_id": 503, "entry_name": "Pier Rovers"},
 			{"id": 74, "entry_id": 504, "entry_name": "Quay Town"},
@@ -84,7 +84,7 @@ func TestViewRendersBothSides(t *testing.T) {
 		t.Fatal(err)
 	}
 	view := m.View()
-	for _, want := range []string{"Harbor FC", "(you)", "Dock United", "Striker", "GW1", "bench"} {
+	for _, want := range []string{"Harbor FC", "Ava Stone", "(you)", "Dock United", "Striker", "GW1", "bench"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %q:\n%s", want, view)
 		}


### PR DESCRIPTION
## What changed
The matchday TUI renders each manager's real name (player_first_name + player_last_name from league details) dimmed under their team name — you know people, not team names.

## Why
Team names are pseudonyms; the human behind them is the context that matters when scouting a matchup.

## How to test
`go test ./cmd/tui/` (render assertion added, fictional fixture name) · real-data `--once` frame verified.

## Commands run
gofmt, go vet, go test.

## Risks / Edge cases
Entries without a name render nothing (no blank line). Names appear only in the local terminal from local league data — nothing enters tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)