### PR TITLE
docs: bring README/CLAUDE/Desktop/PLAN current

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,7 @@ fpl-draft-mcp/
 │   ├── mcp-server/          # Go MCP server (port 8080)
 │   │   ├── cmd/
 │   │   │   ├── dev/                     # the ONLY component that hits the live FPL API
+│   │   │   ├── tui/                     # live matchday dashboard (bubbletea; local snapshots only)
 │   │   │   └── schema-inventory/        # dev utility: dumps API schema registry
 │   │   └── fpl-server/
 │   │       ├── main.go                  # Entry point, registers all 14 tools, auth, /mcp
@@ -396,6 +397,7 @@ fpl-draft-mcp/
 │   │       ├── gw_report.go             # Post-GW review (matchup breakdown + lineup efficiency)
 │   │       ├── manager_card.go          # One manager: record/form/schedule/H2H/draft (composes builders below)
 │   │       ├── epl.go                   # Real PL standings + fixture results
+│   │       ├── deadlines.go             # Per-GW trades/waivers/lock calendar (kickoff-anchored, tz-correct)
 │   │       ├── data_common.go           # Shared bootstrap parsing + game meta
 │   │       ├── manager_*.go / head_to_head.go / draft_picks.go   # Builders composed by manager_card
 │   │       ├── player_gw_stats.go       # Per-GW player stats tool
@@ -421,6 +423,8 @@ fpl-draft-mcp/
 │   └── derived/             # same convention: flat = 2025-26, <season>/ = new seasons
 │       ├── summary/         # league/standings/transactions summaries
 │       └── reports/         # GW markdown reports
+├── Makefile                 # all operations (serve/fetch/derive/weekly/tui/autopilot/update)
+├── scripts/                 # autorefresh + autopilot install/uninstall + preflight + notifications
 ├── CLAUDE.md
 └── README.md
 ```

--- a/PLAN.md
+++ b/PLAN.md
@@ -25,3 +25,5 @@ per section. Status: `[ ]` todo, `[~]` in progress, `[x]` done.
 - [x] `my_week` v1 (heuristic start/sit + attention flags) — 2026-08-21; match model upgrades its scoring later.
 - [x] `trade_check` + `league_pulse` — 2026-08-21.
 - [x] Season-aware legacy tools + drop_radar + `.env` config (LEAGUE_ID/ENTRY_ID/API key).
+- [x] gw_live (live H2H tracker) + matchday TUI (bubbletea) + tool surface consolidated 34→14 — 2026-08-21/22.
+- [x] Ops autopilot (launchd server + 15-min refresh) + deadline intelligence (per-GW calendar, TUI countdown, macOS notifications) — 2026-08-22.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,17 @@ start/sit) → Go MCP server (:8080, 14 tools) → Claude Desktop / Claude Code
 | `waiver_plan` | Who do I add/drop? Roster-aware, labeled `upgrade` / `stream` / `hold` over two horizons |
 | `my_week` | Who starts this GW? Best XI, bench, and attention flags (injuries, blanks, unknowns) |
 | `trade_check` | Is this trade good? Give vs get on season value + starter scarcity (VOR) |
-| `league_pulse` | What's happening? Standings, named transactions, game clock |
+| `league_pulse` | What's happening? Standings, named transactions, game clock + this week's deadlines (trades/waivers/lineup lock, in EST) |
 | `drop_radar` | Who hit the wire? Ownership diffs from element-status snapshots |
 | `team_env` | Shootout or stalemate? Per-team points/xG generated and conceded, by position and venue |
 | `gw_live` | How's my matchup going? Live H2H tracker: both XIs with in-play points (refresh mid-match) |
+
+**Game day:** `make tui` opens a live terminal dashboard — your H2H matchup
+(any matchup, ←/→) with per-player in-play points, manager names, and a
+countdown to the next deadline. The autopilot keeps it fresh and sends macOS
+notifications when a gameweek finalizes and at 24h/3h/2h before every
+deadline — each derived from that GW's own kickoff-anchored clock, so
+midweek and festive schedules follow automatically.
 
 Plus 5 data-layer tools — `manager_card` (one manager: record, form,
 schedule, H2H, draft picks), `current_roster`, `player_gw_stats`, `epl`
@@ -105,13 +112,16 @@ apps/
   mcp-server/            Go module
     fpl-server/          14 MCP tool handlers + HTTP server (X-API-Key auth)
     cmd/dev/             FPL data fetcher (the only live-API component)
+    cmd/tui/             live matchday dashboard (bubbletea)
     internal/            fetch, store, ledger, points, summary, config
   backend/               Python package
     backend/ml/          ingestion → parquet, projection model, waiver_plan,
                          my_week, drop-radar, specs (treat *_SPEC.md as contracts)
-    tests/               pytest suite (300 tests, no network)
+    tests/               pytest suite (306 tests, no network)
 data/                    Raw + derived FPL data (gitignored; flat = 25/26 archive)
 docs/                    Setup + design docs
+scripts/                 autorefresh (launchd/cron), autopilot install, preflight, notifications
+Makefile                 every operation: serve/fetch/derive/weekly/tui/autopilot/update/...
 PLAN.md / STATE.md / ISSUES.md   Living roadmap, checkpoint, known issues
 ```
 

--- a/docs/CLAUDE_DESKTOP.md
+++ b/docs/CLAUDE_DESKTOP.md
@@ -23,12 +23,17 @@ Python CLIs read `.env` automatically (a real exported env var always wins).
 
 ## 1. Start the server
 
+Recommended (macOS): install the autopilot once — always-on server plus a
+fetch+derive refresh every 15 minutes and deadline notifications:
+
 ```bash
-make serve
+make autopilot        # undo: make autopilot-off · pause/resume: make stop / make start
+make update           # after every merged PR: pull + restart the server
 ```
 
-(Restart it — Ctrl-C, `make serve` — after every `git pull`: `go run` compiles
-at launch, so a running server never picks up new code.)
+Manual alternative: `make serve` in a terminal (Ctrl-C to stop; restart after
+every `git pull` — `go run` compiles at launch, so a running server never
+picks up new code).
 
 Path convention: flat roots are the 2025-26 archive; every tool resolves
 season-nested paths from `--default-season` unless a call passes `season`.


### PR DESCRIPTION
## What changed
Docs-only refresh to match shipped reality: README gains the game-day story (TUI, deadline countdown, notifications, kickoff-anchored scheduling) and corrected layout/test counts; CLAUDE.md tree adds cmd/tui, deadlines.go, Makefile, scripts/; CLAUDE_DESKTOP leads with the autopilot as the recommended mode; PLAN.md ticks everything shipped 08-21/22 (match model remains the open Phase 3 item).

## Why
The last two days shipped ten PRs; the living docs are the contract and were one iteration behind.

## How to test
Read the diffs — no code changes.

## Commands run
None needed (docs only); CI runs regardless.

## Risks / Edge cases
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)