### PR TITLE
docs: refresh root docs; drop empty packages/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,52 +1,21 @@
 # AGENTS
 
+**`CLAUDE.md` is the canonical agent contract for this repository** — read it
+first and follow it exactly (engineering standards, architecture, workflow,
+and the non-negotiable rules). This file is only the quick orientation.
+
 ## Project Summary
-- FPL Draft Agent: Go MCP server, Python backend, and a lightweight web UI.
-- Local-only data lives in `data/` and generated output in `reports/` (both git-ignored).
+- FPL Draft Co-Pilot: Go MCP server (14 tools) + Python ML pipeline (uv),
+  used from Claude Desktop/Code. See `README.md`.
+- Local-only data lives in `data/` and `reports/` (git-ignored — never commit).
 
-## Repo Layout
-- `apps/mcp-server/`: Go MCP tools + HTTP server.
-- `apps/backend/`: Python API, scheduler, CLI, and agent logic.
-- `apps/web/`: Web UI.
-- `data/`, `reports/`: local only, do not commit.
+## Setup
+- Go 1.25+ and [uv](https://docs.astral.sh/uv/) (no system Python needed).
+- Copy `.env.example` to `.env` (three variables; never commit secrets).
+- All operations: `Makefile` at the repo root (`make preflight` before any PR).
 
-## Setup Notes
-- Go 1.23+ and Python 3.11+.
-- Copy `.env.example` to `.env` for local runs (never commit secrets).
-- `FPL_MCP_API_KEY` is required for MCP server + backend; `OPENAI_API_KEY` enables LLM features.
-
-## Safeguards (for Codex)
-- Never modify or commit `.env`, secrets, or anything under `data/` or `reports/`.
-- Keep changes minimal and scoped to the issue; avoid sweeping refactors unless requested.
-- Preserve Go MCP tool names/args and response shapes used by the Python backend.
-- If requirements are unclear or repro steps are missing, ask for clarification before changing code.
-- Update README or other docs if user-facing behavior or setup changes.
-
-## Required Tests (before any PR)
-- Run `scripts/preflight.sh`.
-- If any step fails, fix the issue or report failure; do not open a PR with failing tests.
-- If the change affects areas not covered by `preflight`, add or run relevant tests and list them in the PR summary.
-
-## Common Commands (run from repo root)
-- Preflight:
-  `scripts/preflight.sh`
-- Go checks:
-  `cd apps/mcp-server && go vet ./...`
-  `cd apps/mcp-server && go test ./...`
-- Python checks:
-  `python -m compileall apps/backend/backend`
-- Backend dev server:
-  `PYTHONPATH=apps/backend uvicorn backend.server:app --reload --port 8000`
-
-## Issue Handling Guidelines
-- Start with a brief plan and risk assessment.
-- Reproduce or validate the issue using available steps; request missing details if blocked.
-- Implement the smallest correct fix, add tests where practical, and avoid unrelated changes.
-- Run required tests and summarize results in the final response.
-
-## Review Guidelines (for Codex)
-- Do not commit secrets, `.env`, or any files under `data/` or `reports/`.
-- For Go MCP changes, keep tool names/args backward-compatible with the Python backend.
-- For Python backend changes, ensure MCP tool calls and response shapes match server outputs.
-- For UI changes, keep routes aligned with backend endpoints and update README if startup steps change.
-- If changes are non-trivial, run the checks listed above or explain why they were skipped.
+## Hard Rules (abridged — full list in CLAUDE.md §15)
+- Never commit `.env`, secrets, league/entry ids, or anything under `data/`.
+- Never push to `main`; feature branch → PR → all checks green → reviewed merge.
+- No live FPL API calls in tests; fixtures only.
+- Keep changes minimal and scoped; update docs when behavior changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
-## Unreleased
-- Repo re-org to apps/packages layout.
-- GitHub workflows and templates.
-- README refresh and release hygiene.
+## Unreleased (2026-27 season reshape)
+- Reshaped into a draft + weekly-manager co-pilot: Claude (Desktop/Code) as the
+  client over a 14-tool MCP surface (decision layer: draft_board, player_card,
+  waiver_plan, my_week, trade_check, league_pulse, drop_radar, team_env, gw_live).
+- Season projection model (honest walk-forward selection, baseline-in-the-zoo)
+  + 2026-27 draft board; unprojected players surfaced for human judgment,
+  never valued as zero.
+- Season-aware data layout (flat roots = 2025-26 archive; `<root>/<season>/`).
+- Live matchday: gw_live tool + terminal TUI (bubbletea) with deadline countdown.
+- Deadline intelligence: per-GW trades/waivers/lineup calendar (kickoff-anchored,
+  tz-correct) + macOS notifications.
+- Ops: root Makefile, macOS autopilot (always-on server + 15-min refresh),
+  Python packaging moved to uv (pyproject + lockfile).
+- Tool surface consolidated 34 → 14; legacy OpenAI/FastAPI chat stack deprecated.
 
 ## 0.2.0
 - Initial public release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,19 +3,21 @@
 Thanks for helping improve FPL Draft Agent.
 
 ## Development Setup
-- Go code lives in `apps/mcp-server/`.
-- Python backend lives in `apps/backend/`.
-- Web UI lives in `apps/web/`.
+- Go code lives in `apps/mcp-server/` (server, fetcher, TUI).
+- Python ML pipeline lives in `apps/backend/` (managed by [uv](https://docs.astral.sh/uv/)
+  via `pyproject.toml` + `uv.lock` — `uv sync` once, `uv add <pkg>` for dependencies).
+- `apps/web/` is the deprecated legacy UI (kept for history; not developed).
 
 ## Local Checks
-- Go vet: `go vet ./...` from `apps/mcp-server/`.
-- Go test: `go test ./...` from `apps/mcp-server/`.
-- Go format: `gofmt -w .` from `apps/mcp-server/`.
-- Go mod tidy: `go mod tidy` from `apps/mcp-server/` (ensure no diffs in go.mod/go.sum).
-- Python compile: `python -m compileall apps/backend/backend` from repo root.
-- Python tooling: `pip install ruff pytest` (in your active venv).
-- Python lint: `ruff check` from repo root.
-- Python tests: `PYTHONPATH=apps/backend pytest` from repo root.
+One command runs everything CI runs:
+
+```bash
+make preflight   # go vet/test/gofmt + uv sync + ruff + pytest
+```
+
+Individually: `go test ./...` / `gofmt -w .` / `go mod tidy` from
+`apps/mcp-server/`; `uv run ruff check .` / `uv run pytest` from `apps/backend/`.
+Note: CI enforces `go mod tidy` producing no diff.
 
 ## Pull Requests
 - Keep PRs focused and include a short summary.

--- a/README.md
+++ b/README.md
@@ -139,5 +139,5 @@ and entry ids live in `.env` only — never in tracked files.
 
 `apps/backend`'s FastAPI chat server, OpenAI agent, RAG index, and
 APScheduler (`server.py`, `agent.py`, `llm.py`, `rag.py`, `scheduler.py`)
-are the pre-MCP-client stack: kept compiling and tested, deprecated, not
-developed. Claude over MCP replaced them.
+plus the `apps/web` UI are the pre-MCP-client stack: kept for history,
+deprecated, not developed. Claude over MCP replaced them.


### PR DESCRIPTION
## What changed
- AGENTS.md rewritten: defers to CLAUDE.md as the canonical agent contract; removes the stale Codex safeguards section and OpenAI-era setup.
- CONTRIBUTING.md: local checks are now `make preflight` + uv workflow (pip/PYTHONPATH era removed); apps/web marked as deprecated legacy.
- CHANGELOG.md: Unreleased section now describes the 2026-27 co-pilot reshape instead of the ancient repo re-org.
- README Legacy section names apps/web.
- Removed the empty `packages/.gitkeep` placeholder (abandoned layout).

## Why
Professionalism audit of the public repo (user-requested): no personal info found anywhere in tracked files; these were the staleness findings.

## How to test
Docs only — read the diffs.

## Commands run
Repo-wide privacy grep (league/entry ids, team/manager names): zero hits.

## Risks / Edge cases
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)