### PR TITLE
fix: GitHub automation targets trunk flow (main, not retired dev/stage)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,15 @@
-## Summary
-What does this PR change?
+## What changed
+-
 
-## Testing
-- [ ] go test ./... (apps/mcp-server)
-- [ ] go vet ./... (apps/mcp-server)
-- [ ] python -m compileall apps/backend/backend
+## Why
+-
 
-## Checklist
-- [ ] I updated docs if needed.
-- [ ] I added or updated tests if needed.
-- [ ] I verified report generation or UI changes if applicable.
+## How to test
+-
+
+## Commands run
+<!-- make preflight covers everything CI runs (go vet/test/gofmt + uv ruff/pytest) -->
+-
+
+## Risks / Edge cases
+-

--- a/.github/claude/prompts/changelog.md
+++ b/.github/claude/prompts/changelog.md
@@ -1,8 +1,7 @@
 You are Claude Code generating a structured changelog for the FPL Draft Agent repository.
 
-This runs automatically when code crosses one of two gated branch transitions:
-- `dev → stage`   → generates a **pre-release** changelog
-- `stage → main`  → generates a **release** changelog
+This runs when a release is cut from `main` (trunk-based flow: feature
+branch → PR → main; releases are tagged from main).
 
 The workflow will provide you with:
 - The transition type and version label

--- a/.github/claude/prompts/review.md
+++ b/.github/claude/prompts/review.md
@@ -1,22 +1,10 @@
 You are Claude Code performing an automated code review for the FPL Draft Agent repository.
 
-This review fires only on two gated branch transitions:
-- `dev → stage`   (integration gate — pre-release validation)
-- `stage → main`  (production gate — release approval)
-
-Feature-branch PRs never reach this workflow.
-
----
-
-## Transition Context
-
-The workflow will tell you which transition this is (`dev→stage` or `stage→main`).
-Calibrate your strictness accordingly:
-
-| Transition | Gate purpose | Strictness |
-|---|---|---|
-| `dev → stage` | Pre-release integration check | High — catch regressions before staging |
-| `stage → main` | Production release approval | Critical — breaking changes must be documented |
+This repository uses trunk-based flow: every PR targets `main` directly, and
+this review fires on all of them. `main` is production — an approval from you
+means the change is safe to ship. Calibrate strictness accordingly: high for
+everything, critical scrutiny for anything touching data correctness, model
+selection/validation, the MCP tool contracts, or CI itself.
 
 ---
 

--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -6,12 +6,12 @@ name: Claude Issue Agent
 # Trigger (manual):     workflow_dispatch with an issue_number input.
 #
 # What it does:
-#   1. Checks out `dev` and creates a branch  claude/issue-<number>-<run_id>
+#   1. Checks out `main` and creates a branch  claude/issue-<number>-<run_id>
 #   2. Sets up Go + Python environments and installs all dependencies.
 #   3. Builds a task prompt from the issue body and runs Claude Code.
 #   4. Claude edits files directly in the working directory.
 #   5. Runs scripts/preflight.sh (ruff, pytest, go vet, go test).
-#   6. On success: commits, pushes the branch, and opens a draft PR → dev.
+#   6. On success: commits, pushes the branch, and opens a draft PR → main.
 #   7. On failure: posts a preflight log comment on the issue; no PR is opened.
 #
 # Required secret: CLAUDE_CODE_OAUTH_TOKEN (added automatically by the Claude GitHub App)
@@ -105,10 +105,10 @@ jobs:
           fi
 
       # ── Checkout + branch ──────────────────────────────────────────────────
-      - name: Checkout dev
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: main
           fetch-depth: 0
 
       - name: Create work branch
@@ -274,8 +274,8 @@ jobs:
             const issueTitle  = "${{ steps.fetch_issue.outputs.title }}";
             const branch      = process.env.BRANCH;
 
-            // List files changed relative to dev.
-            const files = execSync("git diff --name-only origin/dev...HEAD")
+            // List files changed relative to main.
+            const files = execSync("git diff --name-only origin/main...HEAD")
               .toString().trim();
             const fileLines = files
               ? files.split("\n").map(f => `- \`${f}\``).join("\n")
@@ -300,7 +300,7 @@ jobs:
               repo:  context.repo.repo,
               title: `Claude: ${issueTitle} (#${issueNumber})`,
               head:  branch,
-              base:  "dev",
+              base:  "main",
               body,
               draft: true,
             });


### PR DESCRIPTION
## What changed
- `claude-issue.yml`: checkout, diff base, and PR base all moved from the retired `dev` branch to `main` (the agent would have branched from a frozen commit and opened PRs into a dead branch).
- `.github/claude/prompts/review.md`: dev→stage/stage→main transition framing replaced with trunk reality — every PR targets `main`, which is production.
- `.github/claude/prompts/changelog.md`: framed around releases tagged from `main`.
- `PULL_REQUEST_TEMPLATE.md`: now matches CLAUDE.md §9 exactly, with `make preflight` as the commands reference.

## Why
The branch model was retired 2026-07-30 (trunk-based, Docling-style); the automation layer was never migrated. Found via a docs audit.

## How to test
Grep `.github/` for dev/stage branch refs → none remain; workflow YAML parses. Real validation happens the next time the `claude` issue label fires.

## Commands run
Repo grep + YAML parse check (config-only change; preflight unaffected).

## Risks / Edge cases
claude-issue.yml behavior changes only in its checkout/PR targets; its required-secret guards are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)