### PR TITLE
feat: near-live matchday — --live-only fetch, 60s loop, TUI fast refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,13 @@ derive:
 ## weekly: the whole weekly loop (fetch + derive)
 weekly: fetch derive
 
-## matchday: manual 5-min refresh loop (only needed if autopilot is off)
+## livefetch: minimal in-play refresh — current GW live points only (~2s)
+livefetch:
+	cd apps/mcp-server && go run ./cmd/dev --season $(SEASON) $(GO_ROOTS) --live-only --refresh-now
+
+## matchday: near-live loop for game days — live points every 60s, full refresh every 10 min
 matchday:
-	while true; do $(MAKE) fetch; date; sleep 300; done
+	bash scripts/matchday.sh
 
 ## preflight: full local CI (Go vet/test/fmt + uv sync/ruff/pytest)
 preflight:

--- a/apps/mcp-server/cmd/dev/main.go
+++ b/apps/mcp-server/cmd/dev/main.go
@@ -49,6 +49,7 @@ func main() {
 		summaryRisks    = flag.String("summary-risks", "low,med,high", "comma-separated risk levels for summaries")
 		season          = flag.String("season", "", "season label (e.g. 2026-27): nests raw/derived roots as <root>/<season>. Empty = legacy flat layout (the 2025-26 archive) — pass it for all new-season fetches so old seasons are never overwritten")
 		elementStatus   = flag.Bool("element-status", true, "fetch league element-status (ownership) and archive a timestamped snapshot for the drop-radar")
+		liveOnly        = flag.Bool("live-only", false, "minimal in-play refresh: game meta + current GW live points only (for near-live matchday tracking)")
 	)
 	flag.Parse()
 
@@ -101,6 +102,19 @@ func main() {
 	var game GameMeta
 	if err := json.Unmarshal(gameBody, &game); err != nil {
 		log.Fatal(err)
+	}
+
+	// --live-only: the near-live matchday path. One small GET for the current
+	// GW's live points (plus the game clock already fetched above) and exit —
+	// cheap enough to run every minute during matches.
+	if *liveOnly {
+		gw := game.CurrentEvent
+		if gw == 0 {
+			gw = game.NextEvent
+		}
+		must(client.EventLive(gw, true))
+		log.Printf("live-only refresh: GW %d\n", gw)
+		return
 	}
 
 	refreshBootstrap := forceAll || scheduledActive

--- a/apps/mcp-server/cmd/tui/main.go
+++ b/apps/mcp-server/cmd/tui/main.go
@@ -84,7 +84,7 @@ func doTick() tea.Cmd {
 
 func runFetch() tea.Cmd {
 	return func() tea.Msg {
-		cmd := exec.Command("make", "fetch")
+		cmd := exec.Command("make", "livefetch")
 		cmd.Dir = repoRootGuess()
 		return refreshDone{err: cmd.Run()}
 	}

--- a/docs/CLAUDE_DESKTOP.md
+++ b/docs/CLAUDE_DESKTOP.md
@@ -74,7 +74,7 @@ make weekly     # fetch + ownership + waiver + my_week
 During matches, keep `gw_live` fresh in a second terminal:
 
 ```bash
-make matchday   # full fetch every 5 minutes; Ctrl-C when the day's games end
+make matchday   # near-live: live points every 60s + full refresh every 10 min; Ctrl-C after the games
 ```
 
 Automate weekly with cron: see the crontab example in scripts/weekly.sh.

--- a/scripts/matchday.sh
+++ b/scripts/matchday.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Near-live matchday loop: live points every 60s, full refresh + derive every
+# 10 minutes (keeps waiver/my_week artifacts and non-live files current too).
+# Usage: make matchday   (Ctrl-C when the day's fixtures end)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "near-live matchday loop: live points every 60s, full refresh every 10 min (Ctrl-C to stop)"
+i=0
+while true; do
+  if [ $((i % 10)) -eq 0 ]; then
+    make fetch derive || echo "full refresh failed — retrying next cycle"
+  else
+    make livefetch || echo "live fetch failed — retrying next cycle"
+  fi
+  i=$((i + 1))
+  sleep 60
+done


### PR DESCRIPTION
## What changed
- `cmd/dev --live-only`: minimal in-play refresh — game clock + current GW's live points only (~2s, one small GET). Exits before all heavy fetch/derive paths.
- `make livefetch` target exposing it; `make matchday` is now a near-live loop (live points every 60s, full fetch + derive every 10 min) via scripts/matchday.sh.
- TUI `r` key uses the fast path (livefetch) — on-demand refresh drops from ~20s to ~2s.
- Desktop guide updated.

## Why
During matches only one file meaningfully changes (live points). Fetching just that every minute gives screen freshness at the FPL API's own update floor (~1-3 min) while staying API-polite; the full loop stays on its 10-min/15-min cadences.

## How to test
`go test ./...` (7/7 pkgs) · live-verified: `--live-only` run against the real API completed in ~2s and wrote gw/1/live.json · bash -n on the loop script.

## Commands run
gofmt, go vet, go build, go test · live --live-only run · make -n livefetch.

## Risks / Edge cases
- --live-only forces the live GET every call (bounded by the 60s loop cadence — matchday-only usage).
- Pre-season/no-current-event falls back to next_event.
- Autopilot cadence unchanged; matchday loop is opt-in per game day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)