### PR TITLE
feat: TUI self-feeds live points every 60s while open

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then turn on the autopilot (macOS) — after this, no routine commands at all:
 make autopilot   # always-on server + data/artifact refresh every 15 min (launchd)
 make update      # after a merge: pull latest code + restart the server
 make stop / make start   # pause / resume without uninstalling
-make tui         # live matchup dashboard in the terminal on game days
+make tui         # game days: self-feeding live dashboard (auto-fetch every 60s)
 make autopilot-off
 ```
 

--- a/apps/mcp-server/cmd/tui/main.go
+++ b/apps/mcp-server/cmd/tui/main.go
@@ -82,6 +82,15 @@ func doTick() tea.Cmd {
 	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg { return tick(t) })
 }
 
+// fetchTick drives the self-feeding live refresh: while the TUI is open it
+// pulls the current GW's live points every minute (the --live-only path), so
+// no separate matchday loop is needed for a near-live screen.
+type fetchTick time.Time
+
+func doFetchTick() tea.Cmd {
+	return tea.Tick(60*time.Second, func(t time.Time) tea.Msg { return fetchTick(t) })
+}
+
 func runFetch() tea.Cmd {
 	return func() tea.Msg {
 		cmd := exec.Command("make", "livefetch")

--- a/apps/mcp-server/cmd/tui/model.go
+++ b/apps/mcp-server/cmd/tui/model.go
@@ -286,7 +286,10 @@ func (m *model) reload() error {
 
 func (m *model) Init() tea.Cmd {
 	_ = m.reload()
-	return doTick()
+	// Kick one live fetch immediately, then every minute (self-feeding).
+	m.fetching = true
+	m.status = "fetching…"
+	return tea.Batch(doTick(), doFetchTick(), runFetch())
 }
 
 func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -294,6 +297,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tick:
 		_ = m.reload()
 		return m, doTick()
+	case fetchTick:
+		if m.fetching {
+			return m, doFetchTick()
+		}
+		m.fetching = true
+		m.status = "auto-refreshing…"
+		return m, tea.Batch(doFetchTick(), runFetch())
 	case refreshDone:
 		m.fetching = false
 		if msg.err != nil {

--- a/docs/CLAUDE_DESKTOP.md
+++ b/docs/CLAUDE_DESKTOP.md
@@ -71,10 +71,12 @@ The decision tools serve files the pipeline writes. Before waivers each week
 make weekly     # fetch + ownership + waiver + my_week
 ```
 
-During matches, keep `gw_live` fresh in a second terminal:
+During matches, `make tui` is self-feeding (auto-fetches live points every
+60s while open; `r` forces one now). Headless alternative — keep `gw_live`
+fresh for Claude without the dashboard:
 
 ```bash
-make matchday   # near-live: live points every 60s + full refresh every 10 min; Ctrl-C after the games
+make matchday   # live points every 60s + full refresh every 10 min; Ctrl-C after
 ```
 
 Automate weekly with cron: see the crontab example in scripts/weekly.sh.


### PR DESCRIPTION
## What changed
The matchday TUI now drives its own freshness: on launch it fires one `--live-only` fetch immediately, then re-fetches live points every 60 seconds for as long as it's open (guarded against overlap; `r` still forces one on demand). `make matchday` demoted in docs to the headless alternative (keeping gw_live fresh for Claude without the dashboard).

## Why
One command should be the whole game-day experience — previously a near-live screen required a second terminal running the fetch loop.

## How to test
`go test ./cmd/tui/` (pure pipeline unchanged; ticks are additive) · go vet/build clean · behavior: open TUI, observe "auto-refreshing…" each minute and the data timestamp advancing without any other process.

## Commands run
gofmt, go vet, go build, go test (all pkgs).

## Risks / Edge cases
- Fetch failures set a status line and retry next minute — never crash the UI.
- Fetching stops when the TUI closes (tick lifecycle owned by bubbletea).
- --once mode unaffected (no ticks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)