### PR TITLE
feat: TUI 2x2 grid layout, wide mode from 90 cols

### DIFF
--- a/apps/mcp-server/cmd/tui/view.go
+++ b/apps/mcp-server/cmd/tui/view.go
@@ -18,18 +18,15 @@ type mode int
 const (
 	minimal mode = iota
 	narrow
-	medium
 	wide
 )
 
 func (m *model) mode() mode {
 	switch {
-	case m.w >= 120:
-		return wide // matchup + side rail
-	case m.w >= 96:
-		return medium // matchup only, both squads, bars
+	case m.w >= 90:
+		return wide // 2×2 grid — fits a half-screen terminal split
 	case m.w >= 72:
-		return narrow // both squads, no bars, bench collapsed
+		return narrow // matchup only, no bars, bench collapsed
 	default:
 		return minimal // scoreboard + top scorers only
 	}
@@ -258,7 +255,7 @@ func (m *model) matchupBody(width int) string {
 	}
 
 	collapse := md <= narrow
-	bars := md >= medium
+	bars := md == wide
 	cols := lipgloss.JoinHorizontal(lipgloss.Top,
 		lipgloss.NewStyle().Width(half).Render(squadColumn(mu.A, half, bars, collapse, mp)),
 		styDim.Render("│ "),

--- a/apps/mcp-server/cmd/tui/view.go
+++ b/apps/mcp-server/cmd/tui/view.go
@@ -655,31 +655,15 @@ func (m *model) View() string {
 				w, m.focus == 0) + "\n" + m.footer()
 	}
 
-	leagueW, liveW, txW := 0, 0, 0
-	if md == wide {
-		leagueW = clamp(w/4, 30, 36)
-		if len(m.snap.Matches) > 0 {
-			liveW = clamp(w/6, 20, 24)
-		}
-		txW = clamp(w-66-leagueW-liveW-3, 0, 30)
-		if txW < 18 || m.matchView {
-			txW = 0 // the match view borrows this room for uncut lineups
-		}
+	// Wide layout is a 2×2 grid: Live | Matchup on top, League | Transactions
+	// below. Each row spans the full width, so panels get more room.
+	liveW := 0
+	if md == wide && len(m.snap.Matches) > 0 {
+		liveW = clamp(w/6, 20, 24)
 	}
-	mainW := w - leagueW - liveW - txW
-	for _, pw := range []int{leagueW, liveW, txW} {
-		if pw > 0 {
-			mainW--
-		}
-	}
-	capW := 66
-	if m.matchView {
-		capW = 92
-	}
-	if md == wide && mainW > capW {
-		slack := mainW - capW
-		mainW = capW
-		leagueW = clamp(leagueW+slack, 30, 44)
+	mainW := w - liveW - boolToInt(liveW > 0)
+	if md == wide && mainW > 96 {
+		mainW = 96
 	}
 
 	mainTitle := fmt.Sprintf("Matchup %d/%d", m.selected+1, len(m.snap.Matchups))
@@ -705,7 +689,9 @@ func (m *model) View() string {
 		livePanel := Panel(gamesTitle, gamesHint, m.liveBody(liveW-4, m.focus == 1), liveW, m.focus == 1)
 		screen = lipgloss.JoinHorizontal(lipgloss.Top, livePanel, " ", screen)
 	}
-	if leagueW > 0 {
+	if md == wide {
+		leagueW := clamp(w/2, 30, 50)
+		txW := clamp(w-leagueW-1, 18, 50)
 		leagueTitle, leagueHint := "League", "tab ↑↓ ↵"
 		leagueBody := m.railBody(leagueW-4, m.focus == 2)
 		if m.sugView {
@@ -713,11 +699,8 @@ func (m *model) View() string {
 			leagueBody = m.sugDetailBody(leagueW - 4)
 		}
 		league := Panel(leagueTitle, leagueHint, leagueBody, leagueW, m.focus == 2)
-		screen = lipgloss.JoinHorizontal(lipgloss.Top, screen, " ", league)
-	}
-	if txW > 0 {
 		tx := Panel("Transactions", "↑↓ ↵", m.txBody(txW-4, m.focus == 3), txW, m.focus == 3)
-		screen = lipgloss.JoinHorizontal(lipgloss.Top, screen, " ", tx)
+		screen += "\n" + lipgloss.JoinHorizontal(lipgloss.Top, league, " ", tx)
 	}
 
 	out := m.header(w)


### PR DESCRIPTION
## What changed
- Wide layout is now a 2×2 grid: Live/Played | Matchup on the top row, League | Transactions on the bottom — same panel order as before
- Each row spans the full terminal width: League/Transactions grow to 50 cols (full team names, no truncation), Matchup up to 96 cols, and the match view no longer needs to hide the Transactions panel for lineup space
- Wide breakpoint lowered 120 → 90 cols so the full grid renders in a half-screen terminal split (Ghostty ⌘D with Claude Code alongside); the now-unreachable `medium` mode was removed

## Why
In a split terminal the old single-row layout fell back to matchup-only below 120 cols. The grid needs only ~90 cols per row, so the full dashboard fits beside an editor/Claude pane.

## How to test
`make tui` fullscreen → 2×2 grid; split the terminal (~100 cols) → same four panels, narrower. `--once --width 100` renders all panels in CI-style check.

## Commands run
- go fmt ./... / go vet ./... / go test ./... (all green)

## Risks / Edge cases
- Below 90 cols the narrow/minimal fallbacks are unchanged
- Grid is taller than the old single row; short terminals may need fullscreen height

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117RZpErsWjFXWN8ccjiDmB