### PR TITLE
fix: surface awarded bonus in gw_live and correct the stale note

### DIFF
--- a/apps/mcp-server/fpl-server/gw_live.go
+++ b/apps/mcp-server/fpl-server/gw_live.go
@@ -33,8 +33,11 @@ type gwLiveStats struct {
 	TotalPoints int `json:"total_points"`
 	GoalsScored int `json:"goals_scored"`
 	Assists     int `json:"assists"`
-	Bonus       int `json:"bonus"`
-	Bps         int `json:"bps"`
+	// Bonus is awarded live by the FPL API during matches and is already
+	// included in TotalPoints — never add it on top. Bps is the running
+	// tally it is derived from, and can still move until the whistle.
+	Bonus int `json:"bonus"`
+	Bps   int `json:"bps"`
 }
 
 func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest, GwLiveArgs) (*mcp.CallToolResult, any, error) {
@@ -168,7 +171,8 @@ func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest,
 					"slot": p.Position, "starter": starter,
 					"web_name": info.Name, "position": info.Pos, "team": info.Team,
 					"minutes": stats.Minutes, "points": stats.TotalPoints,
-					"goals": stats.GoalsScored, "assists": stats.Assists, "bps": stats.Bps,
+					"goals": stats.GoalsScored, "assists": stats.Assists,
+					"bonus": stats.Bonus, "bps": stats.Bps,
 				})
 			}
 			return map[string]any{
@@ -184,7 +188,7 @@ func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest,
 		}
 		result := map[string]any{
 			"gw": gw, "me": me,
-			"note": "In-play points are provisional: bonus is estimated from BPS until the day's last match ends, and everything locks the morning after the GW's final match. Refresh the snapshot with a full (non --fast) fetch.",
+			"note": "Points come straight from the FPL live endpoint and already include any bonus awarded so far — bonus is now published during matches, not after. Bonus can still move while a match is in progress (bps shows the running tally); scores lock the morning after the GW's final match. Refresh the snapshot with a full (non --fast) fetch.",
 		}
 		if opponentEntry != 0 {
 			if opp, err := side(opponentEntry); err == nil {

--- a/apps/mcp-server/fpl-server/gw_live_test.go
+++ b/apps/mcp-server/fpl-server/gw_live_test.go
@@ -49,8 +49,11 @@ func TestGwLiveTracksBothSidesOfTheMatchup(t *testing.T) {
 	})
 	writeFixture(t, filepath.Join(season, "gw/1/live.json"), map[string]any{
 		"elements": map[string]any{
+			// total_points already includes the 3 awarded bonus: the tool
+			// must pass it through, not add bonus on top of it.
 			"1": map[string]any{"stats": map[string]any{
-				"minutes": 45, "total_points": 8, "goals_scored": 1, "bps": 29}},
+				"minutes": 45, "total_points": 8, "goals_scored": 1,
+				"bonus": 3, "bps": 29}},
 			"2": map[string]any{"stats": map[string]any{
 				"minutes": 45, "total_points": 6, "goals_scored": 1}},
 			"3": map[string]any{"stats": map[string]any{
@@ -69,6 +72,9 @@ func TestGwLiveTracksBothSidesOfTheMatchup(t *testing.T) {
 		`"bench_points": 6`, // ...but visible separately
 		`"live_points": 1`,  // opponent's keeper
 		"Striker",
+		`"bonus": 3`,  // awarded bonus is surfaced, not just its bps
+		`"points": 8`, // ...and points stay as the API reported them
+		`"bonus": 0`,  // match in progress, none awarded yet (opp keeper)
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("gw_live missing %q: %s", want, text)


### PR DESCRIPTION
## What changed
- `gw_live` now emits `bonus` in each player row alongside `bps`.
- Rewrote the tool `note`: points come from the FPL live endpoint and already include any bonus awarded so far; `bps` is the running tally that can still move while a match is in progress; scores lock the morning after the GW's final match.
- Documented the invariant on `gwLiveStats.Bonus` — it is already inside `TotalPoints`, never add it on top.
- Extended the `gw_live` test with a regression case.

## Why
The FPL live endpoint now publishes bonus **during** matches rather than after the day's last match. Two consequences:

1. The note claimed bonus was "estimated from BPS until the day's last match ends" — no longer true, and misleading to an LLM client reading the tool output, which would hedge a settled scoreline as provisional.
2. `stats.Bonus` was parsed but never emitted, so callers saw only `bps` and had to back the bonus out of `total_points` by hand.

Verified against the live GW1 snapshot: 19 players already carry an awarded bonus mid-gameweek (e.g. White `bonus=2`, `bps=37`, `total=11` = 2 appearance + 3 assist + 4 clean sheet + 2 bonus).

No scoring math changed — the handler passes `total_points` through untouched, as it always did.

## How to test
```
cd apps/mcp-server && go test ./fpl-server -run TestGwLive -v
```
Or call the tool against a live snapshot and confirm each player row carries `bonus`, and that `points` equals what `data/raw/<season>/gw/<n>/live.json` reports.

## Commands run
- `go fmt ./...`
- `go vet ./...`
- `go test ./...` (all packages pass)

## Risks / Edge cases
- **Additive output change only** — a new key in each player row. No existing field changed shape or value, so MCP clients are unaffected.
- Players with no bonus yet report `bonus: 0` (covered by the test) rather than omitting the key.
- Pre-2026-27 archived snapshots that predate live bonus still parse fine: missing `bonus` unmarshals to 0.
- The TUI computes its own provisional bonus from BPS (`cmd/tui/model.go:310`), but `ptsLabel` prefers the real `bonus` and only falls back to the estimate when it is zero — no double-count, so it is left unchanged in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)