### PR TITLE
feat: projected auto-subs (draft rules engine) in gw_live and the TUI

### DIFF
--- a/apps/mcp-server/cmd/tui/model.go
+++ b/apps/mcp-server/cmd/tui/model.go
@@ -252,11 +252,19 @@ func load(dir, derived string, league, entry, gwArg int) (snapshot, int, error) 
 	_ = readJSON(filepath.Join(dir, fmt.Sprintf("gw/%d/live.json", gw)), &live) // pre-kickoff: zeros
 
 	type fxState struct{ started, finished bool }
+	// Merge per team across a double gameweek: started once any fixture has
+	// kicked off, finished only when every fixture is done.
 	fixtureByTeam := map[int]fxState{}
 	for _, f := range live.Fixtures {
 		done := f.Finished || f.FinishedProv
-		fixtureByTeam[f.TeamH] = fxState{f.Started, done}
-		fixtureByTeam[f.TeamA] = fxState{f.Started, done}
+		for _, team := range []int{f.TeamH, f.TeamA} {
+			cur, seen := fixtureByTeam[team]
+			if !seen {
+				fixtureByTeam[team] = fxState{f.Started, done}
+				continue
+			}
+			fixtureByTeam[team] = fxState{cur.started || f.Started, cur.finished && done}
+		}
 	}
 
 	var bootstrap struct {

--- a/apps/mcp-server/cmd/tui/model.go
+++ b/apps/mcp-server/cmd/tui/model.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/aatrey56/FPL-Draft-Agent/apps/mcp-server/internal/autosub"
 )
 
 type playerRow struct {
@@ -29,17 +31,19 @@ type playerRow struct {
 	Bonus   int // confirmed bonus (already inside Points)
 	Prov    int // provisional bonus from live BPS (not yet in Points)
 	Starter bool
-	Glyph   string // ● on pitch, ◉ in squad could appear, ✓ played, – DNP, ○ not yet, ⚠ doubt, · bench
+	SubIn   bool   // projected auto-sub: this bench player comes on
+	Glyph   string // ● on pitch, ◉ could appear, ✓ played, ✗ DNP, ○ not yet, ⚠ doubt, ⇄ auto-sub in, · bench
 }
 
 type side struct {
-	Name    string
-	Manager string
-	EntryID int
-	Total   int
-	Bench   int
-	Played  int
-	Players []playerRow
+	Name      string
+	Manager   string
+	EntryID   int
+	Total     int
+	Effective int // Total plus projected auto-subs (equal when none fire)
+	Bench     int
+	Played    int
+	Players   []playerRow
 }
 
 type matchup struct{ A, B side }
@@ -474,6 +478,28 @@ func load(dir, derived string, league, entry, gwArg int) (snapshot, int, error) 
 				s.Bench += row.Points
 			}
 			s.Players = append(s.Players, row)
+		}
+		s.Effective = s.Total
+		// Project end-of-GW auto-subs (only meaningful once fixtures exist).
+		if len(fixtureByTeam) > 0 {
+			posCode := map[string]int{"GKP": autosub.GKP, "DEF": autosub.DEF, "MID": autosub.MID, "FWD": autosub.FWD}
+			sq := make([]autosub.Player, 0, len(s.Players))
+			for _, p := range s.Players {
+				fx, known := fixtureByTeam[p.TeamID]
+				sq = append(sq, autosub.Player{
+					Slot: p.Slot, Pos: posCode[p.Pos], Minutes: p.Minutes,
+					FixtureDone: !known || fx.finished,
+				})
+			}
+			for _, sw := range autosub.Project(sq) {
+				for i := range s.Players {
+					if s.Players[i].Slot == sw.In {
+						s.Players[i].SubIn = true
+						s.Players[i].Glyph = "⇄"
+						s.Effective += s.Players[i].Points
+					}
+				}
+			}
 		}
 		return s
 	}

--- a/apps/mcp-server/cmd/tui/model_test.go
+++ b/apps/mcp-server/cmd/tui/model_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,6 +186,56 @@ func TestPlayedGamesListAfterLiveAndOpenLineups(t *testing.T) {
 	for _, want := range []string{"LEE 2", "0 HUL", "FT", "EarlyBird"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("played-game lineups missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestMatchupProjectsAutoSubs(t *testing.T) {
+	dir := fixtureDir(t)
+	// Full legal XI (1 GKP, 3 DEF, 4 MID, 3 FWD) so the auto-sub engine can
+	// validate formations. The MID in slot 5 blanked in a finished fixture;
+	// the bench DEF played and must be projected in.
+	elements := []map[string]any{{"id": 1, "web_name": "Keeper", "element_type": 1, "team": 1}}
+	picks := []map[string]any{{"element": 1, "position": 1}}
+	stats := map[string]any{}
+	types := []int{2, 2, 2, 3, 3, 3, 3, 4, 4, 4}
+	for i, et := range types {
+		id := i + 2
+		elements = append(elements, map[string]any{
+			"id": id, "web_name": fmt.Sprintf("Player%d", id), "element_type": et, "team": 1,
+		})
+		picks = append(picks, map[string]any{"element": id, "position": id})
+		stats[fmt.Sprintf("%d", id)] = map[string]any{"stats": map[string]any{"minutes": 90, "total_points": 2}}
+	}
+	stats["1"] = map[string]any{"stats": map[string]any{"minutes": 90, "total_points": 2}}
+	stats["5"] = map[string]any{"stats": map[string]any{"minutes": 0, "total_points": 0}}
+	elements = append(elements, map[string]any{"id": 20, "web_name": "BenchDef", "element_type": 2, "team": 1})
+	picks = append(picks, map[string]any{"element": 20, "position": 12})
+	stats["20"] = map[string]any{"stats": map[string]any{"minutes": 30, "total_points": 5}}
+	write(t, filepath.Join(dir, "bootstrap/bootstrap-static.json"), map[string]any{
+		"elements": elements,
+		"teams":    []map[string]any{{"id": 1, "short_name": "ARS"}, {"id": 2, "short_name": "COV"}},
+	})
+	write(t, filepath.Join(dir, "entry/501/gw/1.json"), map[string]any{"picks": picks})
+	write(t, filepath.Join(dir, "gw/1/live.json"), map[string]any{
+		"elements": stats,
+		"fixtures": []map[string]any{{"team_h": 1, "team_a": 2, "finished": true, "started": true}},
+	})
+
+	snap, myIndex, err := load(dir, t.TempDir(), 5, 501, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mine := snap.Matchups[myIndex].A
+	if mine.EntryID != 501 {
+		mine = snap.Matchups[myIndex].B
+	}
+	if mine.Total != 20 || mine.Effective != 25 {
+		t.Fatalf("total %d effective %d, want 20/25", mine.Total, mine.Effective)
+	}
+	for _, p := range mine.Players {
+		if p.Name == "BenchDef" && p.Glyph != "⇄" {
+			t.Fatalf("projected sub should carry ⇄, got %q", p.Glyph)
 		}
 	}
 }

--- a/apps/mcp-server/cmd/tui/model_test.go
+++ b/apps/mcp-server/cmd/tui/model_test.go
@@ -239,3 +239,50 @@ func TestMatchupProjectsAutoSubs(t *testing.T) {
 		}
 	}
 }
+
+func TestDoubleGameweekDefersAutoSub(t *testing.T) {
+	dir := fixtureDir(t)
+	// Same squad as the auto-sub test, but the blanked MID's club has a
+	// second, unfinished fixture — no substitution may be projected yet.
+	elements := []map[string]any{{"id": 1, "web_name": "Keeper", "element_type": 1, "team": 1}}
+	picks := []map[string]any{{"element": 1, "position": 1}}
+	stats := map[string]any{}
+	types := []int{2, 2, 2, 3, 3, 3, 3, 4, 4, 4}
+	for i, et := range types {
+		id := i + 2
+		elements = append(elements, map[string]any{
+			"id": id, "web_name": fmt.Sprintf("Player%d", id), "element_type": et, "team": 1,
+		})
+		picks = append(picks, map[string]any{"element": id, "position": id})
+		stats[fmt.Sprintf("%d", id)] = map[string]any{"stats": map[string]any{"minutes": 90, "total_points": 2}}
+	}
+	stats["1"] = map[string]any{"stats": map[string]any{"minutes": 90, "total_points": 2}}
+	stats["5"] = map[string]any{"stats": map[string]any{"minutes": 0, "total_points": 0}}
+	elements = append(elements, map[string]any{"id": 20, "web_name": "BenchDef", "element_type": 2, "team": 1})
+	picks = append(picks, map[string]any{"element": 20, "position": 12})
+	stats["20"] = map[string]any{"stats": map[string]any{"minutes": 30, "total_points": 5}}
+	write(t, filepath.Join(dir, "bootstrap/bootstrap-static.json"), map[string]any{
+		"elements": elements,
+		"teams":    []map[string]any{{"id": 1, "short_name": "ARS"}, {"id": 2, "short_name": "COV"}},
+	})
+	write(t, filepath.Join(dir, "entry/501/gw/1.json"), map[string]any{"picks": picks})
+	write(t, filepath.Join(dir, "gw/1/live.json"), map[string]any{
+		"elements": stats,
+		"fixtures": []map[string]any{
+			{"team_h": 1, "team_a": 2, "finished": true, "started": true},
+			{"team_h": 2, "team_a": 1, "finished": false, "started": false},
+		},
+	})
+
+	snap, myIndex, err := load(dir, t.TempDir(), 5, 501, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mine := snap.Matchups[myIndex].A
+	if mine.EntryID != 501 {
+		mine = snap.Matchups[myIndex].B
+	}
+	if mine.Effective != mine.Total {
+		t.Fatalf("DGW with an unfinished fixture must not project a sub: total %d effective %d", mine.Total, mine.Effective)
+	}
+}

--- a/apps/mcp-server/cmd/tui/view.go
+++ b/apps/mcp-server/cmd/tui/view.go
@@ -114,7 +114,7 @@ func scoreBar(me, opp, width int) string {
 
 func glyphStyle(g string, pts int) lipgloss.Style {
 	switch g {
-	case "●":
+	case "●", "⇄":
 		return styLive
 	case "◉":
 		return styFg
@@ -142,7 +142,7 @@ func playerLine(p playerRow, half, barW, maxPts int) string {
 	base := p.Glyph + " " + fmt.Sprintf("%-4s", p.Pos) +
 		name + strings.Repeat(" ", max(0, nameW-lipgloss.Width(name))) + fixedTail
 	sty := glyphStyle(p.Glyph, p.Points)
-	if !p.Starter {
+	if !p.Starter && !p.SubIn {
 		sty = styDim
 	}
 	line := sty.Render(base) + pts
@@ -230,9 +230,10 @@ func (m *model) matchupBody(width int) string {
 		lipgloss.NewStyle().Width(half).Render(left), " ",
 		lipgloss.NewStyle().Width(half).Render(right))
 
-	// Diverging score bar with margin label.
+	// Diverging score bar with margin label. Totals include projected
+	// auto-subs; a ⇄ marks a side where one is live.
 	barW := clamp(width-30, 10, 40)
-	margin := mu.A.Total - mu.B.Total
+	margin := mu.A.Effective - mu.B.Effective
 	if mu.B.EntryID == m.entry {
 		margin = -margin
 	}
@@ -243,12 +244,18 @@ func (m *model) matchupBody(width int) string {
 		marginLabel = styWarn.Render(fmt.Sprintf("you %d", margin))
 	}
 	if mu.A.EntryID != m.entry && mu.B.EntryID != m.entry {
-		marginLabel = styDim.Render(fmt.Sprintf("Δ %+d", mu.A.Total-mu.B.Total))
+		marginLabel = styDim.Render(fmt.Sprintf("Δ %+d", mu.A.Effective-mu.B.Effective))
 	}
-	score := fmt.Sprintf("%s  %s  %s   %s",
-		styScore.Render(fmt.Sprintf("%3d", mu.A.Total)),
-		scoreBar(mu.A.Total, mu.B.Total, barW),
-		styFg.Bold(true).Render(fmt.Sprintf("%d", mu.B.Total)),
+	mark := func(s side) string {
+		if s.Effective != s.Total {
+			return styDim.Render("⇄")
+		}
+		return ""
+	}
+	score := fmt.Sprintf("%s%s  %s  %s%s   %s",
+		styScore.Render(fmt.Sprintf("%3d", mu.A.Effective)), mark(mu.A),
+		scoreBar(mu.A.Effective, mu.B.Effective, barW),
+		styFg.Bold(true).Render(fmt.Sprintf("%d", mu.B.Effective)), mark(mu.B),
 		marginLabel)
 	if pad := (width - lipgloss.Width(score)) / 2; pad > 0 {
 		score = strings.Repeat(" ", pad) + score
@@ -271,9 +278,9 @@ func (m *model) liveScore(entryID int) string {
 		mine, opp := -1, -1
 		switch entryID {
 		case mu.A.EntryID:
-			mine, opp = mu.A.Total, mu.B.Total
+			mine, opp = mu.A.Effective, mu.B.Effective
 		case mu.B.EntryID:
-			mine, opp = mu.B.Total, mu.A.Total
+			mine, opp = mu.B.Effective, mu.A.Effective
 		}
 		if mine < 0 {
 			continue

--- a/apps/mcp-server/fpl-server/gw_live.go
+++ b/apps/mcp-server/fpl-server/gw_live.go
@@ -149,12 +149,18 @@ func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest,
 			elByID[e.ID] = elInfo{e.WebName, positions[e.ElementType], teamShort[e.Team], e.ElementType, e.Team}
 		}
 		// A club with no unfinished fixture this GW counts as done — that is
-		// when a 0-minute starter becomes a confirmed non-player.
+		// when a 0-minute starter becomes a confirmed non-player. In a double
+		// gameweek every one of the club's fixtures must be finished.
 		fixtureDone := map[int]bool{}
 		for _, f := range live.Fixtures {
-			done := f.Finished || f.FinishedProv
-			fixtureDone[f.TeamH] = done
-			fixtureDone[f.TeamA] = done
+			fDone := f.Finished || f.FinishedProv
+			for _, team := range []int{f.TeamH, f.TeamA} {
+				merged := fDone
+				if cur, seen := fixtureDone[team]; seen {
+					merged = merged && cur
+				}
+				fixtureDone[team] = merged
+			}
 		}
 		teamDone := func(teamID int) bool {
 			done, known := fixtureDone[teamID]

--- a/apps/mcp-server/fpl-server/gw_live.go
+++ b/apps/mcp-server/fpl-server/gw_live.go
@@ -19,6 +19,8 @@ import (
 	"sort"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/aatrey56/FPL-Draft-Agent/apps/mcp-server/internal/autosub"
 )
 
 type GwLiveArgs struct {
@@ -107,6 +109,12 @@ func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest,
 			Elements map[string]struct {
 				Stats gwLiveStats `json:"stats"`
 			} `json:"elements"`
+			Fixtures []struct {
+				TeamH        int  `json:"team_h"`
+				TeamA        int  `json:"team_a"`
+				Finished     bool `json:"finished"`
+				FinishedProv bool `json:"finished_provisional"`
+			} `json:"fixtures"`
 		}
 		if err := readJSONFile(filepath.Join(rawDir, fmt.Sprintf("gw/%d/live.json", gw)), &live); err != nil {
 			return toolError(fmt.Errorf("no live snapshot for GW %d yet — run a full (non --fast) fetch refresh during or after matches: %w", gw, err)), nil, nil
@@ -132,11 +140,25 @@ func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest,
 			teamShort[t.ID] = t.ShortName
 		}
 		positions := map[int]string{1: "GKP", 2: "DEF", 3: "MID", 4: "FWD"}
-		elByID := map[int]struct {
+		type elInfo struct {
 			Name, Pos, Team string
-		}{}
+			PosCode, TeamID int
+		}
+		elByID := map[int]elInfo{}
 		for _, e := range bootstrap.Elements {
-			elByID[e.ID] = struct{ Name, Pos, Team string }{e.WebName, positions[e.ElementType], teamShort[e.Team]}
+			elByID[e.ID] = elInfo{e.WebName, positions[e.ElementType], teamShort[e.Team], e.ElementType, e.Team}
+		}
+		// A club with no unfinished fixture this GW counts as done — that is
+		// when a 0-minute starter becomes a confirmed non-player.
+		fixtureDone := map[int]bool{}
+		for _, f := range live.Fixtures {
+			done := f.Finished || f.FinishedProv
+			fixtureDone[f.TeamH] = done
+			fixtureDone[f.TeamA] = done
+		}
+		teamDone := func(teamID int) bool {
+			done, known := fixtureDone[teamID]
+			return !known || done
 		}
 
 		side := func(entryID int) (map[string]any, error) {
@@ -155,6 +177,9 @@ func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest,
 			sort.Slice(snapshot.Picks, func(i, j int) bool {
 				return snapshot.Picks[i].Position < snapshot.Picks[j].Position
 			})
+			squad := make([]autosub.Player, 0, len(snapshot.Picks))
+			nameBySlot := map[int]string{}
+			pointsBySlot := map[int]int{}
 			for _, p := range snapshot.Picks {
 				stats := live.Elements[fmt.Sprintf("%d", p.Element)].Stats
 				info := elByID[p.Element]
@@ -167,6 +192,12 @@ func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest,
 				} else {
 					benchTotal += stats.TotalPoints
 				}
+				squad = append(squad, autosub.Player{
+					Slot: p.Position, Pos: info.PosCode, Minutes: stats.Minutes,
+					FixtureDone: teamDone(info.TeamID),
+				})
+				nameBySlot[p.Position] = info.Name
+				pointsBySlot[p.Position] = stats.TotalPoints
 				players = append(players, map[string]any{
 					"slot": p.Position, "starter": starter,
 					"web_name": info.Name, "position": info.Pos, "team": info.Team,
@@ -175,9 +206,24 @@ func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest,
 					"bonus": stats.Bonus, "bps": stats.Bps,
 				})
 			}
+			// Projected end-of-GW auto-subs (draft rules): confirmed 0-minute
+			// starters replaced from the bench, keeper-for-keeper, formation
+			// kept legal. Effective points = live_points with those applied.
+			effective := liveTotal
+			subs := []map[string]any{}
+			if len(live.Fixtures) > 0 {
+				for _, sw := range autosub.Project(squad) {
+					effective += pointsBySlot[sw.In]
+					subs = append(subs, map[string]any{
+						"out": nameBySlot[sw.Out], "in": nameBySlot[sw.In],
+						"in_points": pointsBySlot[sw.In],
+					})
+				}
+			}
 			return map[string]any{
 				"team_name": nameByEntry[entryID], "entry_id": entryID,
-				"live_points": liveTotal, "bench_points": benchTotal,
+				"live_points": liveTotal, "effective_points": effective,
+				"projected_auto_subs": subs, "bench_points": benchTotal,
 				"starters_played": played, "players": players,
 			}, nil
 		}
@@ -188,7 +234,7 @@ func gwLiveHandler(cfg ServerConfig) func(context.Context, *mcp.CallToolRequest,
 		}
 		result := map[string]any{
 			"gw": gw, "me": me,
-			"note": "Points come straight from the FPL live endpoint and already include any bonus awarded so far — bonus is now published during matches, not after. Bonus can still move while a match is in progress (bps shows the running tally); scores lock the morning after the GW's final match. Refresh the snapshot with a full (non --fast) fetch.",
+			"note": "Points come straight from the FPL live endpoint and already include any bonus awarded so far — bonus is now published during matches, not after. Bonus can still move while a match is in progress (bps shows the running tally); scores lock the morning after the GW's final match. effective_points = live_points plus projected_auto_subs: draft auto-substitutions (0-minute starters whose fixture finished, replaced in bench order, keeper-for-keeper, formation kept legal) that will apply when the GW completes. Refresh the snapshot with a full (non --fast) fetch.",
 		}
 		if opponentEntry != 0 {
 			if opp, err := side(opponentEntry); err == nil {

--- a/apps/mcp-server/fpl-server/gw_live_test.go
+++ b/apps/mcp-server/fpl-server/gw_live_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -108,4 +109,61 @@ func resultText2(t *testing.T, res *mcp.CallToolResult) string {
 		t.Fatalf("unexpected content type %T", res.Content[0])
 	}
 	return text.Text
+}
+
+func TestGwLiveProjectsAutoSubs(t *testing.T) {
+	cfg := fixtureConfig(t)
+	season := filepath.Join(cfg.RawRoot, "2026-27")
+
+	writeFixture(t, filepath.Join(season, "game/game.json"), map[string]any{"current_event": 1})
+	writeFixture(t, filepath.Join(season, "league/5/details.json"), map[string]any{
+		"league_entries": []map[string]any{{"id": 71, "entry_id": 501, "entry_name": "Harbor FC"}},
+		"matches":        []map[string]any{},
+	})
+	// XI: GKP + 3 DEF + 4 MID + 3 FWD. The MID in slot 5 blanked (fixture
+	// finished, 0 minutes) — the DEF on the bench played and must come on.
+	elements := []map[string]any{{"id": 1, "web_name": "Keeper", "element_type": 1, "team": 1}}
+	picks := []map[string]any{{"element": 1, "position": 1}}
+	types := []int{2, 2, 2, 3, 3, 3, 3, 4, 4, 4}
+	for i, et := range types {
+		elements = append(elements, map[string]any{
+			"id": i + 2, "web_name": "P" + string(rune('A'+i)), "element_type": et, "team": 1,
+		})
+		picks = append(picks, map[string]any{"element": i + 2, "position": i + 2})
+	}
+	elements = append(elements,
+		map[string]any{"id": 20, "web_name": "BenchDef", "element_type": 2, "team": 1},
+	)
+	picks = append(picks, map[string]any{"element": 20, "position": 12})
+	writeFixture(t, filepath.Join(season, "bootstrap/bootstrap-static.json"), map[string]any{
+		"elements": elements,
+		"teams":    []map[string]any{{"id": 1, "short_name": "ARS"}},
+	})
+	writeFixture(t, filepath.Join(season, "entry/501/gw/1.json"), map[string]any{"picks": picks})
+	stats := map[string]any{}
+	for i := 1; i <= 11; i++ {
+		stats[fmt.Sprintf("%d", i)] = map[string]any{"stats": map[string]any{"minutes": 90, "total_points": 2}}
+	}
+	stats["5"] = map[string]any{"stats": map[string]any{"minutes": 0, "total_points": 0}} // MID blanked
+	stats["20"] = map[string]any{"stats": map[string]any{"minutes": 30, "total_points": 5}}
+	writeFixture(t, filepath.Join(season, "gw/1/live.json"), map[string]any{
+		"elements": stats,
+		"fixtures": []map[string]any{{"team_h": 1, "team_a": 2, "finished": true}},
+	})
+
+	res, _, err := gwLiveHandler(cfg)(context.Background(), nil, GwLiveArgs{LeagueID: 5, EntryID: 501})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := resultText(t, res)
+	for _, want := range []string{
+		`"live_points": 20`,      // named XI: 10 players on 2, one on 0
+		`"effective_points": 25`, // +5 from the projected sub
+		`"in": "BenchDef"`,
+		`"in_points": 5`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("gw_live auto-sub missing %q: %s", want, text)
+		}
+	}
 }

--- a/apps/mcp-server/internal/autosub/autosub.go
+++ b/apps/mcp-server/internal/autosub/autosub.go
@@ -5,7 +5,9 @@
 //     first eligible bench player, in bench-slot order.
 //   - Goalkeepers only swap with goalkeepers; outfielders with outfielders.
 //   - The resulting XI must stay a legal draft formation: 1 GKP, at least
-//     3 DEF, at least 3 MID, at least 1 FWD.
+//     3 DEF, at least 2 MID, at least 1 FWD (5-2-3 is legal). These minimums
+//     come from the draft API itself — bootstrap settings.squad reports
+//     min_play_DEF 3, min_play_MID 2, min_play_FWD 1, min/max_play_GKP 1.
 //   - Only bench players who actually played (minutes > 0) come on.
 //
 // Mid-gameweek this yields a *projection*: a starter counts as a confirmed
@@ -29,7 +31,7 @@ const (
 // one by the keeper-for-keeper swap rule).
 const (
 	minDEF = 3
-	minMID = 3
+	minMID = 2
 	minFWD = 1
 )
 

--- a/apps/mcp-server/internal/autosub/autosub.go
+++ b/apps/mcp-server/internal/autosub/autosub.go
@@ -1,0 +1,98 @@
+// Package autosub projects FPL Draft end-of-gameweek automatic substitutions
+// from a live squad state. The rules (draft edition):
+//
+//   - A starter who finishes the gameweek with 0 minutes is replaced by the
+//     first eligible bench player, in bench-slot order.
+//   - Goalkeepers only swap with goalkeepers; outfielders with outfielders.
+//   - The resulting XI must stay a legal draft formation: 1 GKP, at least
+//     3 DEF, at least 3 MID, at least 1 FWD.
+//   - Only bench players who actually played (minutes > 0) come on.
+//
+// Mid-gameweek this yields a *projection*: a starter counts as a confirmed
+// non-player only once their fixture is finished (or they have no fixture),
+// and a bench player is only eligible once they have minutes on the board.
+// The projection therefore only firms up as the gameweek completes — it never
+// speculates about matches still to be played.
+package autosub
+
+import "sort"
+
+// Position codes follow the FPL element_type convention.
+const (
+	GKP = 1
+	DEF = 2
+	MID = 3
+	FWD = 4
+)
+
+// Formation minimums for a legal draft XI (the GKP count is pinned to exactly
+// one by the keeper-for-keeper swap rule).
+const (
+	minDEF = 3
+	minMID = 3
+	minFWD = 1
+)
+
+// Player is one squad slot as the rules engine sees it.
+type Player struct {
+	Slot        int // 1-11 starters, 12-15 bench in priority order
+	Pos         int // GKP/DEF/MID/FWD element_type code
+	Minutes     int
+	FixtureDone bool // the player's club has no unfinished fixture this GW
+}
+
+// Swap is one projected substitution, by squad slot.
+type Swap struct {
+	Out, In int
+}
+
+// Project returns the auto-substitutions the draft game would apply if the
+// gameweek ended in the given state, in the order they fire.
+func Project(squad []Player) []Swap {
+	bySlot := map[int]Player{}
+	xiCount := map[int]int{}
+	var starters, bench []Player
+	for _, p := range squad {
+		bySlot[p.Slot] = p
+		if p.Slot <= 11 {
+			starters = append(starters, p)
+			xiCount[p.Pos]++
+		} else {
+			bench = append(bench, p)
+		}
+	}
+	// Slot order is the priority order on both sides of the swap.
+	sort.Slice(starters, func(i, j int) bool { return starters[i].Slot < starters[j].Slot })
+	sort.Slice(bench, func(i, j int) bool { return bench[i].Slot < bench[j].Slot })
+
+	legal := func(count map[int]int) bool {
+		return count[DEF] >= minDEF && count[MID] >= minMID && count[FWD] >= minFWD
+	}
+
+	used := map[int]bool{}
+	var swaps []Swap
+	for _, out := range starters {
+		if !out.FixtureDone || out.Minutes > 0 {
+			continue
+		}
+		for _, in := range bench {
+			if used[in.Slot] || in.Minutes == 0 {
+				continue
+			}
+			if (out.Pos == GKP) != (in.Pos == GKP) {
+				continue
+			}
+			xiCount[out.Pos]--
+			xiCount[in.Pos]++
+			if !legal(xiCount) {
+				xiCount[out.Pos]++
+				xiCount[in.Pos]--
+				continue
+			}
+			used[in.Slot] = true
+			swaps = append(swaps, Swap{Out: out.Slot, In: in.Slot})
+			break
+		}
+	}
+	return swaps
+}

--- a/apps/mcp-server/internal/autosub/autosub_test.go
+++ b/apps/mcp-server/internal/autosub/autosub_test.go
@@ -92,3 +92,18 @@ func TestMultipleSwapsShareTheBench(t *testing.T) {
 		t.Fatalf("got %v want %v", got, want)
 	}
 }
+
+func TestFiveTwoThreeIsLegal(t *testing.T) {
+	// Draft API settings.squad: min_play_MID is 2, so a MID can drop out of
+	// a 3-MID XI and be replaced by a FWD (5-2-3).
+	squad := []Player{{Slot: 1, Pos: GKP, Minutes: 90, FixtureDone: true}}
+	pos := []int{DEF, DEF, DEF, DEF, DEF, MID, MID, MID, FWD, FWD}
+	for i, p := range pos {
+		squad = append(squad, Player{Slot: i + 2, Pos: p, Minutes: 90, FixtureDone: true})
+	}
+	squad[8].Minutes = 0 // slot 9, a MID in the 5-3-2, blanked
+	squad = append(squad, Player{Slot: 13, Pos: FWD, Minutes: 90, FixtureDone: true})
+	if got, want := Project(squad), []Swap{{Out: 9, In: 13}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("5-2-3 must be a legal result, got %v want %v", got, want)
+	}
+}

--- a/apps/mcp-server/internal/autosub/autosub_test.go
+++ b/apps/mcp-server/internal/autosub/autosub_test.go
@@ -1,0 +1,94 @@
+package autosub
+
+import (
+	"reflect"
+	"testing"
+)
+
+// xi builds a legal 3-5-2 XI (slots 1-11) where everyone played, then lets
+// tests override individual slots.
+func xi() []Player {
+	squad := []Player{{Slot: 1, Pos: GKP, Minutes: 90, FixtureDone: true}}
+	pos := []int{DEF, DEF, DEF, MID, MID, MID, MID, MID, FWD, FWD}
+	for i, p := range pos {
+		squad = append(squad, Player{Slot: i + 2, Pos: p, Minutes: 90, FixtureDone: true})
+	}
+	return squad
+}
+
+func TestOutfielderReplacedInBenchOrder(t *testing.T) {
+	// The Kudus/Dalot case: a MID finishes the GW on 0 minutes; the first
+	// outfield bench player who played comes on (a DEF — formation stays
+	// legal at 4-4-2).
+	squad := xi()
+	squad[4].Minutes = 0 // slot 5, MID, fixture done
+	squad = append(squad,
+		Player{Slot: 12, Pos: GKP, Minutes: 90, FixtureDone: true},
+		Player{Slot: 13, Pos: DEF, Minutes: 12, FixtureDone: true},
+		Player{Slot: 14, Pos: MID, Minutes: 90, FixtureDone: true},
+	)
+	got := Project(squad)
+	want := []Swap{{Out: 5, In: 13}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestKeeperOnlyReplacedByKeeper(t *testing.T) {
+	squad := xi()
+	squad[0].Minutes = 0 // the GKP did not play
+	squad = append(squad,
+		Player{Slot: 12, Pos: GKP, Minutes: 0, FixtureDone: true}, // backup also blanked
+		Player{Slot: 13, Pos: DEF, Minutes: 90, FixtureDone: true},
+	)
+	if got := Project(squad); got != nil {
+		t.Fatalf("outfielder must never replace a keeper, got %v", got)
+	}
+	squad[11].Minutes = 45 // backup keeper played
+	if got, want := Project(squad), []Swap{{Out: 1, In: 12}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestFormationMinimumSkipsIllegalSwap(t *testing.T) {
+	// A DEF drops out of a 3-DEF XI: replacing him with a MID would leave
+	// 2 DEF, so the engine must skip ahead to the bench DEF.
+	squad := xi()
+	squad[1].Minutes = 0 // slot 2, DEF
+	squad = append(squad,
+		Player{Slot: 13, Pos: MID, Minutes: 90, FixtureDone: true},
+		Player{Slot: 14, Pos: DEF, Minutes: 90, FixtureDone: true},
+	)
+	if got, want := Project(squad), []Swap{{Out: 2, In: 14}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestNoSwapUntilFixtureFinishedOrBenchPlayed(t *testing.T) {
+	squad := xi()
+	squad[4].Minutes, squad[4].FixtureDone = 0, false // match still live
+	squad = append(squad, Player{Slot: 13, Pos: MID, Minutes: 90, FixtureDone: true})
+	if got := Project(squad); got != nil {
+		t.Fatalf("no projection while the starter's match is live, got %v", got)
+	}
+	squad[4].FixtureDone = true
+	squad[11].Minutes = 0 // bench player has not played (yet)
+	if got := Project(squad); got != nil {
+		t.Fatalf("bench player without minutes must not come on, got %v", got)
+	}
+}
+
+func TestMultipleSwapsShareTheBench(t *testing.T) {
+	squad := xi()
+	squad[4].Minutes = 0  // MID out
+	squad[10].Minutes = 0 // FWD out (slot 11)
+	squad = append(squad,
+		Player{Slot: 13, Pos: MID, Minutes: 90, FixtureDone: true},
+		Player{Slot: 14, Pos: FWD, Minutes: 30, FixtureDone: true},
+	)
+	got := Project(squad)
+	want := []Swap{{Out: 5, In: 13}, {Out: 11, In: 14}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}


### PR DESCRIPTION
## What changed
- New `internal/autosub` package: a pure rules engine projecting FPL Draft end-of-GW automatic substitutions — 0-minute starters whose fixtures are finished get replaced in bench-priority order, keeper-for-keeper only, formation kept legal (≥3 DEF, ≥2 MID, ≥1 FWD — minimums verified against the draft API's own `settings.squad`, which confirms `min_play_MID: 2`, so 5-2-3 is legal)
- Projections never speculate: a starter only counts as out once his club has no unfinished fixture (double gameweeks merge correctly), and a bench player only comes in once he has minutes
- `gw_live` tool: each side now returns `effective_points` and `projected_auto_subs: [{out, in, in_points}]`, note updated
- TUI: matchup score bar, margin label, and the League LIVE column use effective totals; a dim `⇄` marks a side with a live projection and the incoming bench player's row renders green with a `⇄` glyph

## Why
Draft applies auto-subs when the GW completes, so XI-only live scores mislead (real case: an opponent's 0-minute Kudus is replaced by Dalot's point — the matchup margin was off by one). The tools now show the score the gameweek will actually settle at, updating as fixtures finish.

## How to test
`go test ./...` — 5 rule-engine cases (bench order, keeper rule, formation minimums incl. 5-2-3, no-speculation, multi-swap), TUI end-to-end (effective totals + ⇄ glyph, DGW deferral), gw_live end-to-end. Verified against the live GW1 snapshot: opponent 16 → effective 17 via Dalot-for-Kudus.

## Commands run
- go fmt ./... / go vet ./... / go test ./... (8/8 packages ok)

## Risks / Edge cases
- Missing `fixtures` array in an old live.json disables projection rather than guessing
- Blank/postponed fixture ⇒ no fixture ⇒ starter is sub-eligible, matching game behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117RZpErsWjFXWN8ccjiDmB