### PR TITLE
feat: TUI neon-night theme, status colours, resolved played count

### DIFF
--- a/apps/backend/backend/ml/MATCH_MODEL_SPEC.md
+++ b/apps/backend/backend/ml/MATCH_MODEL_SPEC.md
@@ -122,3 +122,55 @@ a **volatile weekly number** (management). They share the feature foundation
 (per-90 rates, opponent strength, minutes) but differ in horizon, target, and
 which signals dominate (season = durability + repeatable quality; match = form +
 opponent + who-starts). Keep them as separate modules under `ml/`.
+
+## Fixture-aware market targeting (the waiver product contract)
+
+The model's xP is not the end product — the end product is *"who should I pick
+up because of who they play."* The user's framing (2026-08-23): target
+transactions at players facing bad teams / easy grounds, position-aware —
+a defender against a toothless attack (clean-sheet buy), an attacking mid or
+forward against a leaky defence (goal-involvement buy). Judge every component
+of FPL points, not just goals.
+
+### Two-sided team environment, per venue
+
+For each fixture derive Poisson-style team expectations from `team_env`
+(re-estimated on 26/27 data as it accrues, with the club-change discount):
+
+- `lambda_for` / `lambda_against` per team **split by venue** — "relegation
+  fodder away" and "solid at home" are different opponents.
+- `P(CS)`, expected goals conceded, and expected shots faced (save volume).
+
+### Position × opponent interaction matrix (what to buy, against whom)
+
+| Buy…            | When the opponent…                | Point source captured |
+|-----------------|-----------------------------------|-----------------------|
+| GKP             | attacks poorly (CS odds)          | CS + low GC risk      |
+| GKP (budget)    | concedes many *shots* (weak team) | save points volume    |
+| DEF             | attacks poorly                    | CS, GC, bonus         |
+| DEF (attacking) | + defends set pieces badly        | goal/assist upside    |
+| MID (attacking) | defends poorly (high xGA)         | goals 5 / assists 3   |
+| MID (defensive) | possession-heavy vs their block   | DC threshold points   |
+| FWD             | defends poorly, high line         | goals 4               |
+
+xP decomposes per component (appearance, goals, assists, CS, GC, saves, DC,
+bonus proxy) so tools can explain *which* component the fixture inflates.
+
+### Horizons and outputs
+
+- Score the FA pool + current roster over **1 GW / next 3 GWs / ROS** (CLAUDE.md
+  §5.2 horizons). A pickup for this week's fixture is a different product than
+  a run-of-fixtures hold — surface both.
+- `waiver_plan` consumes fixture-adjusted xP and stays roster-aware (marginal
+  value over my worst startable at that position, league_size=12 scarcity).
+- New derived view `fixture_targets`: per position, top FA-pool players ranked
+  by fixture-adjusted xP over the chosen horizon, with the component driver
+  ("home vs SUN, CS 48%") — this is the "make the most of the market" scan.
+- my_week/trade_check reuse the same per-fixture components so all advice
+  agrees on why.
+
+### Guards
+
+- Early season: shrink team rates toward priors, weight underlying xG/xGA over
+  results; promoted sides get a promoted-team prior, not zeros.
+- Never hardcode user holds (Madjo, Kroupi Jr) — advice layer only.

--- a/apps/mcp-server/cmd/tui/model.go
+++ b/apps/mcp-server/cmd/tui/model.go
@@ -479,7 +479,11 @@ func load(dir, derived string, league, entry, gwArg int) (snapshot, int, error) 
 			row.Glyph = glyph(row)
 			if row.Starter {
 				s.Total += row.Points
-				if row.Minutes > 0 {
+				// "Played" counts resolved starters: minutes on the board,
+				// or a club whose GW is over (a confirmed DNP still counts —
+				// that slot is done producing).
+				fx, known := fixtureByTeam[row.TeamID]
+				if row.Minutes > 0 || !known || fx.finished {
 					s.Played++
 				}
 			} else {

--- a/apps/mcp-server/cmd/tui/model_test.go
+++ b/apps/mcp-server/cmd/tui/model_test.go
@@ -233,6 +233,9 @@ func TestMatchupProjectsAutoSubs(t *testing.T) {
 	if mine.Total != 20 || mine.Effective != 25 {
 		t.Fatalf("total %d effective %d, want 20/25", mine.Total, mine.Effective)
 	}
+	if mine.Played != 11 {
+		t.Fatalf("a confirmed DNP counts as resolved: played %d, want 11", mine.Played)
+	}
 	for _, p := range mine.Players {
 		if p.Name == "BenchDef" && p.Glyph != "⇄" {
 			t.Fatalf("projected sub should carry ⇄, got %q", p.Glyph)

--- a/apps/mcp-server/cmd/tui/panel.go
+++ b/apps/mcp-server/cmd/tui/panel.go
@@ -1,8 +1,9 @@
 package main
 
-// panel.go — the whole feedtui look in one function: a titled box whose
-// border colour signals focus. The title is spliced into the top edge so it
-// costs zero interior rows.
+// panel.go — the whole look in one function: a double-line box whose border
+// signals focus (navy → magenta) with a background-tinted title bar as the
+// first interior row. minHeight pads the body so panels sharing a grid row
+// end on the same line.
 
 import (
 	"strings"
@@ -10,34 +11,32 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Panel renders body inside a rounded box of exactly `width` columns with the
-// title in the top border. focused switches the border to the accent colour.
-func Panel(title, hint, body string, width int, focused bool) string {
-	bc := mutedC
+// Panel renders body inside a box of exactly `width` columns. The title sits
+// on a tinted bar; focused switches the border to the focus colour. minHeight
+// is the minimum body height in rows (0 = natural).
+func Panel(title, hint, body string, width int, focused bool, minHeight int) string {
+	bc := ruleC
 	if focused {
-		bc = accentC
+		bc = focusC
 	}
-	edge := lipgloss.NewStyle().Foreground(bc)
+	inner := width - 4 // border + padding on each side
 
-	left := "╭─ "
-	rightHint := ""
-	rightCap := "─╮"
+	bar := styBarTitle.Render("▍" + title)
+	hintSeg := ""
 	if hint != "" {
-		rightHint = " " + hint + " "
+		hintSeg = styBarHint.Render(hint + " ")
 	}
-	fill := width - lipgloss.Width(left) - lipgloss.Width(title) - 1 -
-		lipgloss.Width(rightHint) - lipgloss.Width(rightCap)
-	if fill < 0 {
-		fill = 0
+	fill := inner - lipgloss.Width(bar) - lipgloss.Width(hintSeg)
+	titleRow := bar + styBarFill.Render(strings.Repeat(" ", max(0, fill))) + hintSeg
+
+	for lipgloss.Height(body) < minHeight {
+		body += "\n"
 	}
-	top := edge.Render(left) + styTitle.Render(title) + edge.Render(" "+strings.Repeat("─", fill)) +
-		styDim.Render(rightHint) + edge.Render(rightCap)
 
 	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder(), false, true, true, true).
+		Border(lipgloss.DoubleBorder()).
 		BorderForeground(bc).
 		Width(width-2).
 		Padding(0, 1)
-
-	return top + "\n" + box.Render(body)
+	return box.Render(titleRow + "\n" + body)
 }

--- a/apps/mcp-server/cmd/tui/theme.go
+++ b/apps/mcp-server/cmd/tui/theme.go
@@ -1,17 +1,23 @@
 package main
 
-// theme.go — nothing outside this file names a raw colour. AdaptiveColor
-// picks per the terminal background so the dashboard reads on light themes.
+// theme.go — nothing outside this file names a raw colour. The palette is
+// "neon night": deep navy chrome, electric cyan brand, hot magenta focus.
+// AdaptiveColor keeps it legible on light terminals.
 
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	accentC = lipgloss.AdaptiveColor{Light: "#8F6408", Dark: "#E7B24C"} // focus, you, brand
-	liveC   = lipgloss.AdaptiveColor{Light: "#256B39", Dark: "#5FBE72"} // in play, points on
-	alertC  = lipgloss.AdaptiveColor{Light: "#A93A22", Dark: "#DE6A50"} // injury, deadline near
-	fgC     = lipgloss.AdaptiveColor{Light: "#131816", Dark: "#DCE3DE"}
-	mutedC  = lipgloss.AdaptiveColor{Light: "#5C6661", Dark: "#8B968F"}
-	ruleC   = lipgloss.AdaptiveColor{Light: "#DCE2DB", Dark: "#28312D"}
+	accentC = lipgloss.AdaptiveColor{Light: "#0F7B8A", Dark: "#7DF9FF"} // brand, you, titles
+	focusC  = lipgloss.AdaptiveColor{Light: "#B3368C", Dark: "#FF6AC1"} // focused panel border
+	liveC   = lipgloss.AdaptiveColor{Light: "#1F8A4C", Dark: "#3DF57C"} // played / in play
+	alertC  = lipgloss.AdaptiveColor{Light: "#C13B37", Dark: "#FF5C57"} // DNP, losing, deadline
+	flagC   = lipgloss.AdaptiveColor{Light: "#B26A00", Dark: "#FFB86C"} // availability warning
+	tmrwC   = lipgloss.AdaptiveColor{Light: "#2E7BB5", Dark: "#8FD6FF"} // has not played yet
+	fgC     = lipgloss.AdaptiveColor{Light: "#131816", Dark: "#E6EDF3"}
+	mutedC  = lipgloss.AdaptiveColor{Light: "#5C6661", Dark: "#7B88A8"}
+	ruleC   = lipgloss.AdaptiveColor{Light: "#C9D2E3", Dark: "#2A3354"} // unfocused borders
+	barBgC  = lipgloss.AdaptiveColor{Light: "#E8ECF5", Dark: "#1A2038"} // panel title bars
+	selBgC  = lipgloss.AdaptiveColor{Light: "#D0DAF0", Dark: "#24304F"} // selected rows
 )
 
 var (
@@ -20,7 +26,18 @@ var (
 	styScore = lipgloss.NewStyle().Bold(true).Foreground(liveC)
 	styLive  = lipgloss.NewStyle().Foreground(liveC)
 	styWarn  = lipgloss.NewStyle().Foreground(alertC)
+	styFlag  = lipgloss.NewStyle().Foreground(flagC)
 	styFg    = lipgloss.NewStyle().Foreground(fgC)
 	styYou   = lipgloss.NewStyle().Bold(true).Foreground(accentC)
-	styTmrw  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#2E7BB5", Dark: "#9BD3F0"})
+	styTmrw  = lipgloss.NewStyle().Foreground(tmrwC)
+	stySel   = lipgloss.NewStyle().Bold(true).Foreground(fgC).Background(selBgC)
+
+	// Title-bar segments — everything on the bar carries its background.
+	styBarTitle = lipgloss.NewStyle().Bold(true).Foreground(accentC).Background(barBgC)
+	styBarHint  = lipgloss.NewStyle().Foreground(mutedC).Background(barBgC)
+	styBarFill  = lipgloss.NewStyle().Background(barBgC)
+
+	// The diverging score bar: lit cells cyan, rest navy.
+	styBarOn  = lipgloss.NewStyle().Foreground(accentC)
+	styBarOff = lipgloss.NewStyle().Foreground(ruleC)
 )

--- a/apps/mcp-server/cmd/tui/view.go
+++ b/apps/mcp-server/cmd/tui/view.go
@@ -112,21 +112,17 @@ func scoreBar(me, opp, width int) string {
 	return styLive.Render(strings.Repeat("█", filled)) + styDim.Render(strings.Repeat("░", width-filled))
 }
 
-func glyphStyle(g string, pts int) lipgloss.Style {
+// glyphStyle is the status colour language: green = played/playing,
+// red = confirmed out (DNP, or flagged ⚠ via styWarn), baby blue = has not
+// played yet, dim = bench.
+func glyphStyle(g string) lipgloss.Style {
 	switch g {
-	case "●", "⇄":
+	case "●", "⇄", "✓":
 		return styLive
-	case "◉":
-		return styFg
-	case "✓":
-		if pts > 0 {
-			return styLive
-		}
-		return styFg
+	case "◉", "○":
+		return styTmrw
 	case "⚠", "✗":
 		return styWarn
-	case "·", "–":
-		return styDim
 	default:
 		return styDim
 	}
@@ -141,7 +137,7 @@ func playerLine(p playerRow, half, barW, maxPts int) string {
 	name := ansi.Truncate(p.Name, nameW, "…")
 	base := p.Glyph + " " + fmt.Sprintf("%-4s", p.Pos) +
 		name + strings.Repeat(" ", max(0, nameW-lipgloss.Width(name))) + fixedTail
-	sty := glyphStyle(p.Glyph, p.Points)
+	sty := glyphStyle(p.Glyph)
 	if !p.Starter && !p.SubIn {
 		sty = styDim
 	}

--- a/apps/mcp-server/cmd/tui/view.go
+++ b/apps/mcp-server/cmd/tui/view.go
@@ -247,7 +247,7 @@ func (m *model) matchupBody(width int) string {
 	}
 	mark := func(s side) string {
 		if s.Effective != s.Total {
-			return styDim.Render("⇄")
+			return styTmrw.Render("⇄")
 		}
 		return ""
 	}

--- a/apps/mcp-server/cmd/tui/view.go
+++ b/apps/mcp-server/cmd/tui/view.go
@@ -244,10 +244,16 @@ func (m *model) matchupBody(width int) string {
 	if mu.A.EntryID != m.entry && mu.B.EntryID != m.entry {
 		marginLabel = styDim.Render(fmt.Sprintf("Δ %+d", mu.A.Effective-mu.B.Effective))
 	}
-	score := fmt.Sprintf("%s  %s  %s   %s",
-		styScore.Render(fmt.Sprintf("%3d", mu.A.Effective)),
+	mark := func(s side) string {
+		if s.Effective != s.Total {
+			return styDim.Render("⇄")
+		}
+		return ""
+	}
+	score := fmt.Sprintf("%s%s  %s  %s%s   %s",
+		styScore.Render(fmt.Sprintf("%3d", mu.A.Effective)), mark(mu.A),
 		scoreBar(mu.A.Effective, mu.B.Effective, barW),
-		styFg.Bold(true).Render(fmt.Sprintf("%d", mu.B.Effective)),
+		styFg.Bold(true).Render(fmt.Sprintf("%d", mu.B.Effective)), mark(mu.B),
 		marginLabel)
 	if pad := (width - lipgloss.Width(score)) / 2; pad > 0 {
 		score = strings.Repeat(" ", pad) + score

--- a/apps/mcp-server/cmd/tui/view.go
+++ b/apps/mcp-server/cmd/tui/view.go
@@ -244,16 +244,10 @@ func (m *model) matchupBody(width int) string {
 	if mu.A.EntryID != m.entry && mu.B.EntryID != m.entry {
 		marginLabel = styDim.Render(fmt.Sprintf("Δ %+d", mu.A.Effective-mu.B.Effective))
 	}
-	mark := func(s side) string {
-		if s.Effective != s.Total {
-			return styDim.Render("⇄")
-		}
-		return ""
-	}
-	score := fmt.Sprintf("%s%s  %s  %s%s   %s",
-		styScore.Render(fmt.Sprintf("%3d", mu.A.Effective)), mark(mu.A),
+	score := fmt.Sprintf("%s  %s  %s   %s",
+		styScore.Render(fmt.Sprintf("%3d", mu.A.Effective)),
 		scoreBar(mu.A.Effective, mu.B.Effective, barW),
-		styFg.Bold(true).Render(fmt.Sprintf("%d", mu.B.Effective)), mark(mu.B),
+		styFg.Bold(true).Render(fmt.Sprintf("%d", mu.B.Effective)),
 		marginLabel)
 	if pad := (width - lipgloss.Width(score)) / 2; pad > 0 {
 		score = strings.Repeat(" ", pad) + score

--- a/apps/mcp-server/cmd/tui/view.go
+++ b/apps/mcp-server/cmd/tui/view.go
@@ -102,14 +102,14 @@ func barStr(pts, maxPts, width int) string {
 	return s
 }
 
-// scoreBar renders the diverging matchup bar: my share in green, rest dim.
+// scoreBar renders the diverging matchup bar: my share lit cyan, rest navy.
 func scoreBar(me, opp, width int) string {
 	total := me + opp
 	if total == 0 {
-		return styDim.Render(strings.Repeat("░", width))
+		return styBarOff.Render(strings.Repeat("▱", width))
 	}
 	filled := clamp(int(float64(me)/float64(total)*float64(width)+0.5), 0, width)
-	return styLive.Render(strings.Repeat("█", filled)) + styDim.Render(strings.Repeat("░", width-filled))
+	return styBarOn.Render(strings.Repeat("▰", filled)) + styBarOff.Render(strings.Repeat("▱", width-filled))
 }
 
 // glyphStyle is the status colour language: green = played/playing,
@@ -121,7 +121,9 @@ func glyphStyle(g string) lipgloss.Style {
 		return styLive
 	case "◉", "○":
 		return styTmrw
-	case "⚠", "✗":
+	case "⚠":
+		return styFlag
+	case "✗":
 		return styWarn
 	default:
 		return styDim
@@ -368,11 +370,12 @@ func (m *model) railBody(width int, focused bool) string {
 			case "↑":
 				sty = styLive
 			}
-			cursor := ""
 			if focused && i == m.sugSel {
-				cursor = styYou.Render("▸ ")
+				row := "▸ " + r.Glyph + " " + ansi.Truncate(r.Name, width-6, "…")
+				b.WriteString(stySel.Render(row+strings.Repeat(" ", max(0, width-lipgloss.Width(row)))) + "\n")
+			} else {
+				b.WriteString(sty.Render(r.Glyph) + " " + styFg.Render(ansi.Truncate(r.Name, width-4, "…")) + "\n")
 			}
-			b.WriteString(cursor + sty.Render(r.Glyph) + " " + styFg.Render(ansi.Truncate(r.Name, width-4, "…")) + "\n")
 			b.WriteString("  " + styDim.Render(ansi.Truncate(r.Note, width-3, "…")) + "\n")
 		}
 	}
@@ -396,12 +399,13 @@ func (m *model) txBody(width int, focused bool) string {
 				missed = t.In
 			}
 		}
-		cursor := "  "
-		if focused && i == m.txSel {
-			cursor = styYou.Render("▸ ")
-		}
 		team := ansi.Truncate(mgr.Name, width-7, "…")
-		b.WriteString(cursor + styDim.Render(fmt.Sprintf("%2d ", mgr.Pick)) + styFg.Render(team) + "\n")
+		if focused && i == m.txSel {
+			row := fmt.Sprintf("▸ %2d %s", mgr.Pick, team)
+			b.WriteString(stySel.Render(row+strings.Repeat(" ", max(0, width-lipgloss.Width(row)))) + "\n")
+		} else {
+			b.WriteString("  " + styDim.Render(fmt.Sprintf("%2d ", mgr.Pick)) + styFg.Render(team) + "\n")
+		}
 		switch {
 		case landed != "":
 			b.WriteString(styLive.Render(ansi.Truncate("    +"+landed, width, "…")) + "\n")
@@ -591,7 +595,8 @@ func (m *model) liveBody(width int, focused bool) string {
 		}
 		line := fmt.Sprintf("%s %d-%d %s %s", g.Home, g.HS, g.AS, g.Away, label)
 		if focused && i == m.liveSel {
-			b.WriteString(styYou.Render("▸ "+line) + "\n")
+			row := "▸ " + line
+			b.WriteString(stySel.Render(row+strings.Repeat(" ", max(0, width-lipgloss.Width(row)))) + "\n")
 		} else {
 			b.WriteString(sty.Render("  "+line) + "\n")
 		}
@@ -607,29 +612,24 @@ func (m *model) liveBody(width int, focused bool) string {
 }
 
 func (m *model) header(width int) string {
-	title := styFg.Bold(true).Render(fmt.Sprintf("FPL · GW%d", m.snap.GW)) + "  " + styLive.Render("◍ LIVE")
+	// Full-width tinted banner; every segment carries the bar background.
+	on := func(sty lipgloss.Style) lipgloss.Style { return sty.Background(barBgC) }
+	title := on(styTitle).Render(fmt.Sprintf(" FPL · GW%d ", m.snap.GW)) + on(styLive).Render("◍ LIVE")
 	due := ""
 	if m.snap.NextDue != "" {
-		due = styYou.Render(m.snap.NextDue)
+		due = on(styYou).Render(m.snap.NextDue)
 	}
-	clock := styFg.Bold(true).Render(time.Now().In(eastern).Format("3:04:05 PM") + " EST")
-	stamp := styDim.Render("data "+m.snap.Loaded.Format("15:04:05")) + " " + styLive.Render("●")
+	clock := on(styFg.Bold(true)).Render(time.Now().In(eastern).Format("3:04:05 PM") + " EST")
+	stamp := on(styDim).Render("data "+m.snap.Loaded.Format("15:04:05")) + on(styLive).Render(" ●")
 	if m.status != "" {
-		stamp += "  " + styDim.Render(m.status)
+		stamp += on(styDim).Render("  " + m.status)
 	}
-	parts := []string{title, due, clock, stamp}
-	line := " "
-	for _, p := range parts {
-		if p == "" {
-			continue
-		}
-		line += " " + p + "  "
+	gap := on(styBarFill).Render("   ")
+	line := title + gap + due + gap + clock + gap + stamp
+	if pad := width - lipgloss.Width(line); pad > 0 {
+		line += styBarFill.Render(strings.Repeat(" ", pad))
 	}
-	if pad := width - lipgloss.Width(line) - 2; pad > 0 {
-		line += strings.Repeat(" ", pad)
-	}
-	box := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(ruleC).Width(width - 2)
-	return box.Render(line)
+	return line
 }
 
 func (m *model) footer() string {
@@ -652,7 +652,7 @@ func (m *model) View() string {
 			Panel(fmt.Sprintf("Matchup %d/%d", m.selected+1, len(m.snap.Matchups)), "← →",
 				sideHeader(mu.A, mu.A.EntryID == m.entry, false, w-6)+"\n\n"+
 					fmt.Sprintf("%s  vs  %s", styScore.Render(fmt.Sprintf("%d", mu.A.Total)), styFg.Bold(true).Render(fmt.Sprintf("%d", mu.B.Total))),
-				w, m.focus == 0) + "\n" + m.footer()
+				w, m.focus == 0, 0) + "\n" + m.footer()
 	}
 
 	// Wide layout is a 2×2 grid: Live | Matchup on top, League | Transactions
@@ -675,7 +675,15 @@ func (m *model) View() string {
 		mainTitle = "Transactions"
 		mainBody = m.txDetailBody(mainW - 4)
 	}
-	matchupPanel := Panel(mainTitle, "← →", mainBody, mainW, m.focus == 0 || m.matchView || m.txView)
+	// Panels sharing a grid row pad to the same body height so the row's
+	// bottom edges align.
+	topH := lipgloss.Height(mainBody)
+	liveBody := ""
+	if liveW > 0 {
+		liveBody = m.liveBody(liveW-4, m.focus == 1)
+		topH = max(topH, lipgloss.Height(liveBody))
+	}
+	matchupPanel := Panel(mainTitle, "← →", mainBody, mainW, m.focus == 0 || m.matchView || m.txView, topH)
 
 	screen := matchupPanel
 	if liveW > 0 {
@@ -686,7 +694,7 @@ func (m *model) View() string {
 		if m.gamesPages() > 1 {
 			gamesHint = "←→ ↑↓ ↵"
 		}
-		livePanel := Panel(gamesTitle, gamesHint, m.liveBody(liveW-4, m.focus == 1), liveW, m.focus == 1)
+		livePanel := Panel(gamesTitle, gamesHint, liveBody, liveW, m.focus == 1, topH)
 		screen = lipgloss.JoinHorizontal(lipgloss.Top, livePanel, " ", screen)
 	}
 	if md == wide {
@@ -698,8 +706,10 @@ func (m *model) View() string {
 			leagueTitle, leagueHint = "Suggestion", "esc"
 			leagueBody = m.sugDetailBody(leagueW - 4)
 		}
-		league := Panel(leagueTitle, leagueHint, leagueBody, leagueW, m.focus == 2)
-		tx := Panel("Transactions", "↑↓ ↵", m.txBody(txW-4, m.focus == 3), txW, m.focus == 3)
+		txBody := m.txBody(txW-4, m.focus == 3)
+		botH := max(lipgloss.Height(leagueBody), lipgloss.Height(txBody))
+		league := Panel(leagueTitle, leagueHint, leagueBody, leagueW, m.focus == 2, botH)
+		tx := Panel("Transactions", "↑↓ ↵", txBody, txW, m.focus == 3, botH)
 		screen += "\n" + lipgloss.JoinHorizontal(lipgloss.Top, league, " ", tx)
 	}
 

--- a/apps/mcp-server/cmd/tui/view.go
+++ b/apps/mcp-server/cmd/tui/view.go
@@ -103,13 +103,14 @@ func barStr(pts, maxPts, width int) string {
 }
 
 // scoreBar renders the diverging matchup bar: my share lit cyan, rest navy.
+// Solid blocks — fancier glyphs render unevenly in some terminal fonts.
 func scoreBar(me, opp, width int) string {
 	total := me + opp
 	if total == 0 {
-		return styBarOff.Render(strings.Repeat("▱", width))
+		return styBarOff.Render(strings.Repeat("░", width))
 	}
 	filled := clamp(int(float64(me)/float64(total)*float64(width)+0.5), 0, width)
-	return styBarOn.Render(strings.Repeat("▰", filled)) + styBarOff.Render(strings.Repeat("▱", width-filled))
+	return styBarOn.Render(strings.Repeat("█", filled)) + styBarOff.Render(strings.Repeat("░", width-filled))
 }
 
 // glyphStyle is the status colour language: green = played/playing,


### PR DESCRIPTION
## What changed
- Player status colour language (user-specced): green = played/playing, red ✗ = confirmed DNP, baby blue = not played yet (○/◉), orange ⚠ = availability flag (now distinct from DNP red)
- "Played" counter counts resolved starters — a confirmed DNP (team's game over) counts, so a finished slot reads as done
- Neon-night theme: electric-cyan brand + score bar (solid █░ blocks — fancy glyphs protrude in some fonts), magenta focus borders vs navy, double-line panel borders, tinted `▍Title` bars with right-aligned hints, full-width banner header (saves 2 rows), background-highlighted selected rows, equal-height panels per grid row
- Score-line ⇄ auto-sub marker in baby blue
- Match-model spec: "Fixture-aware market targeting" contract (position × opponent matrix, venue-split team env, 1/3/ROS horizons, fixture_targets view) for the Monday model session

## Why
Six rounds of visual feedback: status colours the user specced, then a committed "neon night" direction chosen via design consult; played-count fix for confirmed-DNP slots (Kudus case).

## How to test
`make tui` (fullscreen + Ghostty ⌘D split) — statuses green/red/blue/orange, cyan bar, magenta focus, aligned panel bottoms. `--once --width 130` for a static render.

## Commands run
- go fmt / go vet / go test ./... (8/8 ok)

## Risks / Edge cases
- Pure render-layer changes; data pipeline untouched except Played semantics (tested)
- AdaptiveColor keeps light-terminal fallbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117RZpErsWjFXWN8ccjiDmB